### PR TITLE
Fixed nodes2

### DIFF
--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -24,7 +24,7 @@ class Optimiser
 {
   public:
     Optimiser();
-    double optimise_partition(MutableVertexPartition* partition, const vector<size_t> fixed_nodes=vector<size_t>());
+    double optimise_partition(MutableVertexPartition* partition, const vector<size_t> fixed_nodes);
     template <class T> T* find_partition(Graph* graph);
     template <class T> T* find_partition(Graph* graph, double resolution_parameter);
 
@@ -36,13 +36,15 @@ class Optimiser
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool, int consider_comms, int consider_empty_community);
+    double move_nodes(MutableVertexPartition* partition, vector<bool> fixed_nodes, int consider_comms);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes, int consider_comms, int consider_empty_community);
 
     double merge_nodes(MutableVertexPartition* partition);
     double merge_nodes(MutableVertexPartition* partition, int consider_comms);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool, int consider_comms);
+    double merge_nodes(MutableVertexPartition* partition, vector<bool> fixed_nodes, int consider_comms);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes, int consider_comms);
 
     double move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition);
     double move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition);

--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -36,13 +36,13 @@ class Optimiser
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, int consider_empty_community);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool, int consider_comms, int consider_empty_community);
 
     double merge_nodes(MutableVertexPartition* partition);
     double merge_nodes(MutableVertexPartition* partition, int consider_comms);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool, int consider_comms);
 
     double move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition);
     double move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition);

--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -24,7 +24,7 @@ class Optimiser
 {
   public:
     Optimiser();
-    double optimise_partition(MutableVertexPartition* partition, const vector<size_t> fixed_nodes);
+    double optimise_partition(MutableVertexPartition* partition, const vector<bool> fixed_nodes);
     template <class T> T* find_partition(Graph* graph);
     template <class T> T* find_partition(Graph* graph, double resolution_parameter);
 
@@ -32,7 +32,7 @@ class Optimiser
     // Each node will be in the same community in all graphs, and the graphs are expected to have identical nodes
     // Optionally we can loop over all possible communities instead of only the neighbours. In the case of negative
     // layer weights this may be necessary.
-    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, const vector<size_t> fixed_nodes=vector<size_t>());
+    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, const vector<bool> fixed_nodes);
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);

--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -24,7 +24,7 @@ class Optimiser
 {
   public:
     Optimiser();
-    double optimise_partition(MutableVertexPartition* partition);
+    double optimise_partition(MutableVertexPartition* partition, const vector<size_t> fixed_nodes=vector<size_t>());
     template <class T> T* find_partition(Graph* graph);
     template <class T> T* find_partition(Graph* graph, double resolution_parameter);
 
@@ -32,7 +32,7 @@ class Optimiser
     // Each node will be in the same community in all graphs, and the graphs are expected to have identical nodes
     // Optionally we can loop over all possible communities instead of only the neighbours. In the case of negative
     // layer weights this may be necessary.
-    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights);
+    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, const vector<size_t> fixed_nodes=vector<size_t>());
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);
@@ -79,6 +79,7 @@ class Optimiser
     void print_settings();
 
     igraph_rng_t rng;
+    vector<size_t> fixed_nodes;
 };
 
 template <class T> T* Optimiser::find_partition(Graph* graph)

--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -79,7 +79,6 @@ class Optimiser
     void print_settings();
 
     igraph_rng_t rng;
-    vector<size_t> fixed_nodes;
 };
 
 template <class T> T* Optimiser::find_partition(Graph* graph)

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -695,10 +695,13 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
     if (graphs[layer]->vcount() != n)
       throw Exception("Number of nodes are not equal for all graphs.");
 
-  // Establish vertex order
+  // Establish vertex order, skipping fixed nodes
   // We normally initialize the normal vertex order
   // of considering node 0,1,...
-  vector<size_t> vertex_order = range(n);
+  vector<size_t> vertex_order;
+  for (size_t v = 0; v != n; v++)
+    if (!fixed_nodes_bool[v])
+      vertex_order.push_back(v);
 
   // But if we use a random order, we shuffle this order.
   shuffle(vertex_order, &rng);

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -47,7 +47,7 @@ void Optimiser::print_settings()
 /*****************************************************************************
   optimise the provided partition.
 *****************************************************************************/
-double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<size_t> fixed_nodes)
+double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<bool> fixed_nodes)
 {
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
@@ -63,7 +63,7 @@ double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<s
 /*****************************************************************************
   optimise the provided partition.
 *****************************************************************************/
-double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<size_t> fixed_nodes)
+double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes)
 {
   #ifdef DEBUG
     cerr << "void Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<size_t> fixed_nodes)" << endl;

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -85,6 +85,12 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
   // all graphs, so we only take the first one.
   size_t n = graphs[0]->vcount();
 
+  // Set fixed nodes as a boolean vector here
+  vector<bool> fixed_nodes_bool(n, false);
+  for(size_t v = 0; v != fixed_nodes.size(); v++)
+    if (fixed_nodes[v])
+      fixed_nodes_bool[v] = true;
+
   // Make sure that all graphs contain the exact same number of nodes.
   // We assume the index of each vertex in the graph points to the
   // same node (but then in a different layer).
@@ -121,9 +127,9 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
       cerr << "Quality before moving " <<  q << endl;
     #endif
     if (this->optimise_routine == Optimiser::MOVE_NODES)
-      improv += this->move_nodes(collapsed_partitions, layer_weights);
+      improv += this->move_nodes(collapsed_partitions, layer_weights, fixed_nodes_bool);
     else if (this->optimise_routine == Optimiser::MERGE_NODES)
-      improv += this->merge_nodes(collapsed_partitions, layer_weights);
+      improv += this->merge_nodes(collapsed_partitions, layer_weights, fixed_nodes_bool);
 
     #ifdef DEBUG
       cerr << "Found " << collapsed_partitions[0]->n_communities() << " communities, improved " << improv << endl;
@@ -393,12 +399,12 @@ double Optimiser::merge_nodes_constrained(MutableVertexPartition* partition, int
     partitions -- The partitions to optimise.
     layer_weights -- The weights used for the different layers.
 ******************************************************************************/
-double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights)
+double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool)
 {
-  return this->move_nodes(partitions, layer_weights, this->consider_comms, this->consider_empty_community);
+  return this->move_nodes(partitions, layer_weights, fixed_nodes_bool, this->consider_comms, this->consider_empty_community);
 }
 
-double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, int consider_empty_community)
+double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool, int consider_comms, int consider_empty_community)
 {
   #ifdef DEBUG
     cerr << "double Optimiser::move_nodes_multiplex(vector<MutableVertexPartition*> partitions, vector<double> weights)" << endl;
@@ -639,12 +645,12 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
   return total_improv;
 }
 
-double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights)
+double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool)
 {
-  return this->merge_nodes(partitions, layer_weights, this->consider_comms);
+  return this->merge_nodes(partitions, layer_weights, fixed_nodes_bool, this->consider_comms);
 }
 
-double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms)
+double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> fixed_nodes_bool, int consider_comms)
 {
   #ifdef DEBUG
     cerr << "double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> weights)" << endl;

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -47,12 +47,12 @@ void Optimiser::print_settings()
 /*****************************************************************************
   optimise the provided partition.
 *****************************************************************************/
-double Optimiser::optimise_partition(MutableVertexPartition* partition)
+double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<size_t> fixed_nodes)
 {
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->optimise_partition(partitions, layer_weights);
+  return this->optimise_partition(partitions, layer_weights, fixed_nodes);
 }
 
 /*****************************************************************************
@@ -63,10 +63,10 @@ double Optimiser::optimise_partition(MutableVertexPartition* partition)
 /*****************************************************************************
   optimise the provided partition.
 *****************************************************************************/
-double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights)
+double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<size_t> fixed_nodes)
 {
   #ifdef DEBUG
-    cerr << "void Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights)" << endl;
+    cerr << "void Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<size_t> fixed_nodes)" << endl;
   #endif
 
   double q = 0.0;

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -355,7 +355,8 @@ double Optimiser::move_nodes(MutableVertexPartition* partition, int consider_com
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->move_nodes(partitions, layer_weights, consider_comms, this->consider_empty_community);
+  vector<bool> fixed_nodes_bool;
+  return this->move_nodes(partitions, layer_weights, fixed_nodes_bool, consider_comms, this->consider_empty_community);
 }
 
 double Optimiser::merge_nodes(MutableVertexPartition* partition)
@@ -368,7 +369,8 @@ double Optimiser::merge_nodes(MutableVertexPartition* partition, int consider_co
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->merge_nodes(partitions, layer_weights, consider_comms);
+  vector<bool> fixed_nodes_bool;
+  return this->merge_nodes(partitions, layer_weights, fixed_nodes_bool, consider_comms);
 }
 
 double Optimiser::move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition)

--- a/src/Optimiser.py
+++ b/src/Optimiser.py
@@ -242,9 +242,10 @@ class Optimiser(object):
       are run. If the number of iterations is negative, the Leiden algorithm is
       run until an iteration in which there was no improvement.
 
-    fixed_nodes: list or None
-      List of nodes that are not allowed to change community. By default (None)
-      all nodes can change community during the optimization.
+    fixed_nodes: list of bools or None
+      Boolean list of nodes that are not allowed to change community. The
+      length of this list must be equal to the number of nodes. By default
+      (None) all nodes can change community during the optimization.
 
     Returns
     -------
@@ -261,7 +262,10 @@ class Optimiser(object):
 
     or, fixing some nodes:
 
-    >>> diff = optimiser.optimise_partition(partition, fixed_nodes=[0, 1])
+    >>> fixed_nodes = [False for v in G.vs]
+    >>> fixed_nodes[4] = True
+    >>> fixed_nodes[6] = True
+    >>> diff = optimiser.optimise_partition(partition, fixed_nodes=fixed_nodes)
     """
 
     itr = 0
@@ -283,7 +287,7 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2):
+  def optimise_partition_multiplex(self, partitions, layer_weights=None, fixed_nodes=None, n_iterations=2):
     """ Optimise the given partitions simultaneously.
 
     Parameters
@@ -293,6 +297,11 @@ class Optimiser(object):
 
     layer_weights
       List of weights of layers.
+
+    fixed_nodes: list of bools or None
+      Boolean list of nodes that are not allowed to change community. The
+      length of this list must be equal to the number of nodes. By default
+      (None) all nodes can change community during the optimization.
 
     n_iterations : int
       Number of iterations to run the Leiden algorithm. By default, 2 iterations
@@ -371,7 +380,8 @@ class Optimiser(object):
       diff_inc = _c_leiden._Optimiser_optimise_partition_multiplex(
         self._optimiser,
         [partition._partition for partition in partitions],
-        layer_weights)
+        layer_weights,
+        fixed_nodes)
       diff += diff_inc
       itr += 1
       if n_iterations < 0:
@@ -383,13 +393,18 @@ class Optimiser(object):
       partition._update_internal_membership()
     return diff
 
-  def move_nodes(self, partition, consider_comms=None):
+  def move_nodes(self, partition, fixed_nodes=None, consider_comms=None):
     """ Move nodes to alternative communities for *optimising* the partition.
 
     Parameters
     ----------
     partition
       The partition for which to move nodes.
+
+    fixed_nodes: list of bools or None
+      Boolean list of nodes that are not allowed to change community. The
+      length of this list must be equal to the number of nodes. By default
+      (None) all nodes can change community during the optimization.
 
     consider_comms
       If ``None`` uses :attr:`consider_comms`, but can be set to
@@ -423,7 +438,8 @@ class Optimiser(object):
     """
     if (consider_comms is None):
       consider_comms = self.consider_comms
-    diff =  _c_leiden._Optimiser_move_nodes(self._optimiser, partition._partition, consider_comms)
+    diff = _c_leiden._Optimiser_move_nodes(
+            self._optimiser, partition._partition, fixed_nodes, consider_comms)
     partition._update_internal_membership()
     return diff
 
@@ -476,13 +492,18 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def merge_nodes(self, partition, consider_comms=None):
+  def merge_nodes(self, partition, fixed_nodes=None, consider_comms=None):
     """ Merge nodes for *optimising* the partition.
 
     Parameters
     ----------
     partition
       The partition for which to merge nodes.
+
+    fixed_nodes: list of bools or None
+      Boolean list of nodes that are not allowed to change community. The
+      length of this list must be equal to the number of nodes. By default
+      (None) all nodes can change community during the optimization.
 
     consider_comms
       If ``None`` uses :attr:`consider_comms`, but can be set to
@@ -515,7 +536,8 @@ class Optimiser(object):
     """
     if (consider_comms is None):
       consider_comms = self.consider_comms
-    diff =  _c_leiden._Optimiser_merge_nodes(self._optimiser, partition._partition, consider_comms)
+    diff = _c_leiden._Optimiser_merge_nodes(
+            self._optimiser, partition._partition, fixed_nodes, consider_comms)
     partition._update_internal_membership()
     return diff
 

--- a/src/Optimiser.py
+++ b/src/Optimiser.py
@@ -229,7 +229,7 @@ class Optimiser(object):
     """
     _c_leiden._Optimiser_set_rng_seed(self._optimiser, value)
 
-  def optimise_partition(self, partition, n_iterations=2):
+  def optimise_partition(self, partition, n_iterations=2, fixed_nodes=None):
     """ Optimise the given partition.
 
     Parameters
@@ -241,6 +241,10 @@ class Optimiser(object):
       Number of iterations to run the Leiden algorithm. By default, 2 iterations
       are run. If the number of iterations is negative, the Leiden algorithm is
       run until an iteration in which there was no improvement.
+
+    fixed_nodes: list or None
+      List of nodes that are not allowed to change community. By default (None)
+      all nodes can change community during the optimization.
 
     Returns
     -------
@@ -255,13 +259,20 @@ class Optimiser(object):
     >>> partition = la.ModularityVertexPartition(G)
     >>> diff = optimiser.optimise_partition(partition)
 
+    or, fixing some nodes:
+
+    >>> diff = optimiser.optimise_partition(partition, fixed_nodes=[0, 1])
     """
 
     itr = 0
     diff = 0
     continue_iteration = itr < n_iterations or n_iterations < 0
     while continue_iteration:
-      diff_inc = _c_leiden._Optimiser_optimise_partition(self._optimiser, partition._partition)
+      diff_inc = _c_leiden._Optimiser_optimise_partition(
+              self._optimiser,
+              partition._partition,
+              fixed_nodes=fixed_nodes,
+              )
       diff += diff_inc
       itr += 1
       if n_iterations < 0:

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -113,7 +113,7 @@ extern "C"
     PyObject* py_layer_weights = NULL;
     PyObject* py_fixed_nodes = NULL;
 
-    if (!PyArg_ParseTuple(args, "OOO", &py_optimiser, &py_partitions,
+    if (!PyArg_ParseTuple(args, "OOOO", &py_optimiser, &py_partitions,
                                        &py_layer_weights, &py_fixed_nodes))
         return NULL;
 
@@ -274,7 +274,7 @@ extern "C"
     double q  = 0.0;
     try
     {
-      q = optimiser->move_nodes(partition, consider_comms);
+      q = optimiser->move_nodes(partition, fixed_nodes, consider_comms);
     }
     catch (std::exception e)
     {
@@ -349,7 +349,7 @@ extern "C"
     double q = 0.0;
     try
     {
-      q = optimiser->merge_nodes(partition, consider_comms);
+      q = optimiser->merge_nodes(partition, fixed_nodes, consider_comms);
     }
     catch (std::exception e)
     {

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -39,6 +39,7 @@ extern "C"
   {
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
+    PyObject* py_fixed_nodes = NULL;
 
     static char* kwlist[] = {"optimiser", "partition", "fixed_nodes", NULL};
 
@@ -46,7 +47,7 @@ extern "C"
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|O", kwlist,
                                      &py_optimiser, &py_partition,
                                      &py_fixed_nodes))
         return NULL;
@@ -71,30 +72,24 @@ extern "C"
       cerr << "Using partition at address " << partition << endl;
     #endif
 
-    vector<size_t> fixed_nodes;
+    size_t n = partition->get_graph()->vcount();
+    vector<bool> fixed_nodes(n, false);
     if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
     {
       #ifdef DEBUG
         cerr << "Reading fixed_nodes." << endl;
       #endif
 
-      size_t nb_fixed_nodes = PyList_Size(py_node_sizes);
-      node_sizes.resize(nb_fixed_nodes);
+      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
+      if (nb_fixed_nodes != n)
+      {
+        throw Exception("Node size vector not the same size as the number of nodes.");
+      }
+
       for (size_t v = 0; v < n; v++)
       {
         PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
-        #ifdef IS_PY3K
-        if (PyLong_Check(py_item))
-        #else
-        if (PyInt_Check(py_item) || PyLong_Check(py_item))
-        #endif
-        {
-          fixed_nodes[v] = PyLong_AsLong(py_item);
-        }
-        else
-        {
-          throw Exception("Expected integer value for fixed nodes vector.");
-        }
+        fixed_nodes[v] = PyObject_IsTrue(py_item);
       }
     }
 
@@ -116,8 +111,10 @@ extern "C"
     PyObject* py_optimiser = NULL;
     PyObject* py_partitions = NULL;
     PyObject* py_layer_weights = NULL;
+    PyObject* py_fixed_nodes = NULL;
 
-    if (!PyArg_ParseTuple(args, "OOO", &py_optimiser, &py_partitions, &py_layer_weights))
+    if (!PyArg_ParseTuple(args, "OOO", &py_optimiser, &py_partitions,
+                                       &py_layer_weights, &py_fixed_nodes))
         return NULL;
 
     size_t nb_partitions = PyList_Size(py_partitions);
@@ -135,6 +132,7 @@ extern "C"
 
     vector<MutableVertexPartition*> partitions(nb_partitions);
     vector<double> layer_weights(nb_partitions, 1.0);
+    vector<bool> fixed_nodes;
 
     for (size_t layer = 0; layer < nb_partitions; layer++)
     {
@@ -164,6 +162,30 @@ extern "C"
 
       if (isnan(layer_weights[layer]))
         throw Exception("Cannot accept NaN weights.");
+
+      // Fixed nodes are the same for all layers
+      if (layer == 0) {
+        size_t n = partition->get_graph()->vcount();
+        fixed_nodes.resize(n, false);
+        if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+        {
+          #ifdef DEBUG
+            cerr << "Reading fixed_nodes." << endl;
+          #endif
+
+          size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
+          if (nb_fixed_nodes != n)
+          {
+            throw Exception("Node size vector not the same size as the number of nodes.");
+          }
+
+          for (size_t v = 0; v < n; v++)
+          {
+            PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
+            fixed_nodes[v] = PyObject_IsTrue(py_item);
+          }
+        }
+      }
     }
 
     #ifdef DEBUG
@@ -177,7 +199,7 @@ extern "C"
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partitions, layer_weights);
+      q = optimiser->optimise_partition(partitions, layer_weights, fixed_nodes);
     }
     catch (std::exception e)
     {
@@ -191,16 +213,18 @@ extern "C"
   {
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
+    PyObject* py_fixed_nodes = NULL;
     int consider_comms = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "fixed_nodes", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|i", kwlist,
-                                     &py_optimiser, &py_partition, &consider_comms))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
+                                     &py_optimiser, &py_partition,
+                                     &py_fixed_nodes, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -222,6 +246,27 @@ extern "C"
     #ifdef DEBUG
       cerr << "Using partition at address " << partition << endl;
     #endif
+
+    size_t n = partition->get_graph()->vcount();
+    vector<bool> fixed_nodes(n, false);
+    if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+    {
+      #ifdef DEBUG
+        cerr << "Reading fixed_nodes." << endl;
+      #endif
+
+      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
+      if (nb_fixed_nodes != n)
+      {
+        throw Exception("Node size vector not the same size as the number of nodes.");
+      }
+
+      for (size_t v = 0; v < n; v++)
+      {
+        PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
+        fixed_nodes[v] = PyObject_IsTrue(py_item);
+      }
+    }
 
     if (consider_comms < 0)
       consider_comms = optimiser->consider_comms;
@@ -243,16 +288,18 @@ extern "C"
   {
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
+    PyObject* py_fixed_nodes = NULL;
     int consider_comms = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "fixed_nodes", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|i", kwlist,
-                                     &py_optimiser, &py_partition, &consider_comms))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
+                                     &py_optimiser, &py_partition,
+                                     &py_fixed_nodes, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -274,6 +321,27 @@ extern "C"
     #ifdef DEBUG
       cerr << "Using partition at address " << partition << endl;
     #endif
+
+    size_t n = partition->get_graph()->vcount();
+    vector<bool> fixed_nodes(n, false);
+    if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+    {
+      #ifdef DEBUG
+        cerr << "Reading fixed_nodes." << endl;
+      #endif
+
+      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
+      if (nb_fixed_nodes != n)
+      {
+        throw Exception("Node size vector not the same size as the number of nodes.");
+      }
+
+      for (size_t v = 0; v < n; v++)
+      {
+        PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
+        fixed_nodes[v] = PyObject_IsTrue(py_item);
+      }
+    }
 
     if (consider_comms < 0)
       consider_comms = optimiser->consider_comms;

--- a/tests/test_Optimiser.py
+++ b/tests/test_Optimiser.py
@@ -21,6 +21,18 @@ class OptimiserTest(unittest.TestCase):
         partition.sizes(), [100],
         msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after move nodes incorrect.");
 
+  def test_move_nodes_with_fixed(self):
+    # One edge plus singleton, but the two connected nodes are fixed
+    G = ig.Graph([(0, 2)])
+    fixed_nodes = [True, False, True]
+    partition = leidenalg.CPMVertexPartition(
+            G,
+            resolution_parameter=0.1);
+    self.optimiser.move_nodes(partition, fixed_nodes=fixed_nodes, consider_comms=leidenalg.ALL_NEIGH_COMMS);
+    self.assertListEqual(
+        partition.sizes(), [1, 1, 1],
+        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after move nodes incorrect.");
+
   def test_merge_nodes(self):
     G = ig.Graph.Full(100);
     partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.5);

--- a/tests/test_VertexPartition.py
+++ b/tests/test_VertexPartition.py
@@ -175,8 +175,10 @@ class CPMVertexPartitionTest(BaseTest.MutableVertexPartitionTest):
     graph = bipartite_graph
     partition, partition_0, partition_1 = \
         leidenalg.CPMVertexPartition.Bipartite(graph, resolution_parameter_01=0.2)
-    self.optimiser.optimise_partition_multiplex([partition, partition_0, partition_1],
-                                     layer_weights=[1, -1, -1])
+    self.optimiser.optimise_partition_multiplex(
+            [partition, partition_0, partition_1],
+            layer_weights=[1, -1, -1],
+            fixed_nodes=None)
     self.assertEqual(len(partition), 1)
 
 class SurpriseVertexPartitionTest(BaseTest.MutableVertexPartitionTest):


### PR DESCRIPTION
Next iteration of PR #8 on support for fixed nodes. This PR deprecates #8.

This time, as discussed on the phone, I've used Optimiser.optimize_partition and similar Python functions as entry points for an additional optional argument `fixed_nodes`, which is `None` or a list of `bool` of size equal to the number of nodes in the graph (if the list has int or other `True`-able Python objects, that's also ok).

Then I adapted the CPython API files, the `Optimiser.h` header file to include a few overloaded calls for the same functions as above relying on an array of `false` in case no nodes are fixed.

Finally I changed the `Optimiser.cpp` file with the actual implementation:
1. I do not add fixed nodes to the intial queue in `move_nodes`
2. I do not add fixed nodes in the subsequent, fast local moving queue in `move_nodes`
3. I exclude fixed nodes from the iteration in `merge_nodes`
4. I propagate fixed nodes down to the collapsed graphs (if you contain at least a fixed node, you are fixed yourself) in `optimise_partition`, starting from the full list of fixed nodes for the initial graph.

Moreover, I checked that all tests pass locally and added one simple test for two nodes that collapse without fixing but do not with fixing. Bottomline everything looks good from this side.

A few more points as we discussed:
- `move_nodes_constrained` and `merge_nodes_constrained` are untouched.
- nothing is currently done about community renumbering, not even at the very end. I would like you to double check the code and then we can implement that final touch.

Let me know what you think.
