### PR TITLE
Significantly improve performance

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,10 @@ before_build:
   - git submodule update --init --recursive
 
 install:
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy"
   - bash -lc "pacman --noconfirm -S zstd"

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -126,9 +126,9 @@ class Graph
       return this->_edge_weights[e];
     };
 
-    inline void edge(size_t eid, size_t *from, size_t *to) {
-      *from = IGRAPH_FROM(this->get_igraph(), eid);
-      *to = IGRAPH_TO(this->get_igraph(), eid);
+    inline void edge(size_t eid, size_t &from, size_t &to) {
+      from = IGRAPH_FROM(this->get_igraph(), eid);
+      to = IGRAPH_TO(this->get_igraph(), eid);
     }
 
     inline vector<size_t> edge(size_t e)

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -148,7 +148,7 @@ class Graph
 
     inline size_t degree(size_t v, igraph_neimode_t mode)
     {
-      if (mode == IGRAPH_IN)
+      if (mode == IGRAPH_IN || !this->is_directed())
         return this->_degree_in[v];
       else if (mode == IGRAPH_OUT)
         return this->_degree_out[v];
@@ -160,7 +160,7 @@ class Graph
 
     inline double strength(size_t v, igraph_neimode_t mode)
     {
-      if (mode == IGRAPH_IN)
+      if (mode == IGRAPH_IN || !this->is_directed())
         return this->_strength_in[v];
       else if (mode == IGRAPH_OUT)
         return this->_strength_out[v];

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -174,6 +174,7 @@ class Graph
 
   private:
     igraph_t* _graph;
+    igraph_vector_t _temp_igraph_vector;
 
     // Utility variables to easily access the strength of each node
     vector<double> _strength_in;

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -111,7 +111,7 @@ class Graph
     inline size_t ecount() { return igraph_ecount(this->_graph); };
     inline double total_weight() { return this->_total_weight; };
     inline size_t total_size() { return this->_total_size; };
-    inline int is_directed() { return igraph_is_directed(this->_graph); };
+    inline int is_directed() { return this->_is_directed; };
     inline double density() { return this->_density; };
     inline int correct_self_loops() { return this->_correct_self_loops; };
     inline int is_weighted() { return this->_is_weighted; };
@@ -200,6 +200,7 @@ class Graph
     double _total_weight;
     size_t _total_size;
     int _is_weighted;
+    bool _is_directed;
 
     int _correct_self_loops;
     double _density;

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -134,7 +134,7 @@ class Graph
     inline vector<size_t> edge(size_t e)
     {
       vector<size_t> edge(2);
-      this->edge(e, &edge[0], &edge[1]);
+      this->edge(e, edge[0], edge[1]);
       return edge;
     }
 

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -100,8 +100,6 @@ class Graph
     vector<size_t> const& get_neighbours(size_t v, igraph_neimode_t mode);
     size_t get_random_neighbour(size_t v, igraph_neimode_t mode, igraph_rng_t* rng);
 
-    pair<size_t, size_t> get_endpoints(size_t e);
-
     inline size_t get_random_node(igraph_rng_t* rng)
     {
       return get_random_int(0, this->vcount() - 1, rng);
@@ -128,12 +126,15 @@ class Graph
       return this->_edge_weights[e];
     };
 
+    inline void edge(size_t eid, size_t *from, size_t *to) {
+      *from = IGRAPH_FROM(this->get_igraph(), eid);
+      *to = IGRAPH_TO(this->get_igraph(), eid);
+    }
+
     inline vector<size_t> edge(size_t e)
     {
-      igraph_integer_t v1, v2;
-      igraph_edge(this->_graph, e, &v1, &v2);
       vector<size_t> edge(2);
-      edge[0] = v1; edge[1] = v2;
+      this->edge(e, &edge[0], &edge[1]);
       return edge;
     }
 

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -80,7 +80,7 @@ class MutableVertexPartition
     void renumber_communities(map<size_t, size_t> const& original_fixed_membership);
     void renumber_communities(vector<size_t> const& new_membership);
     void set_membership(vector<size_t> const& new_membership);
-    void rearrange_community_labels(vector<size_t> const& new_comm_id);
+    void relabel_communities(vector<size_t> const& new_comm_id);
     vector<size_t> static comm_ids_by_decreasing_size(vector<MutableVertexPartition*> partitions);
     size_t get_empty_community();
     size_t add_empty_community();

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -77,10 +77,11 @@ class MutableVertexPartition
     inline Graph* get_graph() { return this->graph; };
 
     void renumber_communities();
-    vector<size_t> renumber_communities(map<size_t, size_t> const& original_fixed_membership);
+    void renumber_communities(map<size_t, size_t> const& original_fixed_membership);
     void renumber_communities(vector<size_t> const& new_membership);
     void set_membership(vector<size_t> const& new_membership);
-    vector<size_t> static renumber_communities(vector<MutableVertexPartition*> partitions);
+    void rearrange_community_labels(vector<size_t> const& new_comm_id);
+    vector<size_t> static comm_ids_by_decreasing_size(vector<MutableVertexPartition*> partitions);
     size_t get_empty_community();
     size_t add_empty_community();
     void from_coarse_partition(vector<size_t> const& coarse_partition_membership);

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -98,8 +98,33 @@ class MutableVertexPartition
     inline double total_weight_in_all_comms()         { return this->_total_weight_in_all_comms; };
     inline size_t total_possible_edges_in_all_comms() { return this->_total_possible_edges_in_all_comms; };
 
-    double weight_to_comm(size_t v, size_t comm);
-    double weight_from_comm(size_t v, size_t comm);
+    inline double weight_to_comm(size_t v, size_t comm)
+    {
+      if (this->_current_node_cache_community_to != v)
+      {
+        this->cache_neigh_communities(v, IGRAPH_OUT);
+        this->_current_node_cache_community_to = v;
+      }
+
+      if (comm < this->_cached_weight_to_community.size())
+        return this->_cached_weight_to_community[comm];
+      else
+        return 0.0;
+    }
+
+    inline double weight_from_comm(size_t v, size_t comm)
+    {
+      if (this->_current_node_cache_community_from != v)
+      {
+        this->cache_neigh_communities(v, IGRAPH_IN);
+        this->_current_node_cache_community_from = v;
+      }
+
+      if (comm < this->_cached_weight_from_community.size())
+        return this->_cached_weight_from_community[comm];
+      else
+        return 0.0;
+    }
 
     vector<size_t> const& get_neigh_comms(size_t v, igraph_neimode_t);
     set<size_t> get_neigh_comms(size_t v, igraph_neimode_t mode, vector<size_t> const& constrained_membership);

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -114,6 +114,9 @@ class MutableVertexPartition
 
     inline double weight_from_comm(size_t v, size_t comm)
     {
+      if (!this->graph->is_directed())
+        return weight_to_comm(v, comm);
+
       if (this->_current_node_cache_community_from != v)
       {
         this->cache_neigh_communities(v, IGRAPH_IN);

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -81,7 +81,7 @@ class MutableVertexPartition
     void renumber_communities(vector<size_t> const& new_membership);
     void set_membership(vector<size_t> const& new_membership);
     void relabel_communities(vector<size_t> const& new_comm_id);
-    vector<size_t> static comm_ids_by_decreasing_size(vector<MutableVertexPartition*> partitions);
+    vector<size_t> static rank_order_communities(vector<MutableVertexPartition*> partitions);
     size_t get_empty_community();
     size_t add_empty_community();
     void from_coarse_partition(vector<size_t> const& coarse_partition_membership);

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -381,7 +381,7 @@ void Graph::init_admin()
     this->_total_weight += w;
 
     size_t from, to;
-    this->edge(e, &from, &to);
+    this->edge(e, from, to);
 
     if (this->is_directed()) {
       this->_strength_in[to] += w;
@@ -719,7 +719,7 @@ Graph* Graph::collapse_graph(MutableVertexPartition* partition)
     for (size_t v : community_memberships[v_comm]) {
         for (size_t e : this->get_neighbour_edges(v, IGRAPH_OUT)) {
             size_t from, to;
-            this->edge(e, &from, &to);
+            this->edge(e, from, to);
 
             if ((size_t) from != v) {
                 // need to skip because IGRAPH_OUT is ignored for undirected graphs

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -97,6 +97,7 @@ Graph::Graph(igraph_t* graph,
   this->_node_self_weights = node_self_weights;
 
   this->_correct_self_loops = correct_self_loops;
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
 }
 
@@ -120,6 +121,7 @@ Graph::Graph(igraph_t* graph,
   this->_correct_self_loops = this->has_self_loops();
 
   this->_node_self_weights = node_self_weights;
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
 }
 
@@ -140,6 +142,7 @@ Graph::Graph(igraph_t* graph,
   this->_node_sizes = node_sizes;
 
   this->_correct_self_loops = correct_self_loops;
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -161,6 +164,7 @@ Graph::Graph(igraph_t* graph,
 
   this->_correct_self_loops = this->has_self_loops();
 
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -175,6 +179,7 @@ Graph::Graph(igraph_t* graph, vector<double> const& edge_weights, int correct_se
   this->_edge_weights = edge_weights;
   this->_is_weighted = true;
   this->set_default_node_size();
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -191,6 +196,7 @@ Graph::Graph(igraph_t* graph, vector<double> const& edge_weights)
   this->_correct_self_loops = this->has_self_loops();
 
   this->set_default_node_size();
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -207,6 +213,7 @@ Graph::Graph(igraph_t* graph, vector<size_t> const& node_sizes, int correct_self
 
   this->set_default_edge_weight();
   this->_is_weighted = false;
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -225,6 +232,7 @@ Graph::Graph(igraph_t* graph, vector<size_t> const& node_sizes)
 
   this->_correct_self_loops = this->has_self_loops();
 
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -236,6 +244,7 @@ Graph::Graph(igraph_t* graph, int correct_self_loops)
   this->_correct_self_loops = correct_self_loops;
   this->set_defaults();
   this->_is_weighted = false;
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -249,6 +258,7 @@ Graph::Graph(igraph_t* graph)
 
   this->_correct_self_loops = this->has_self_loops();
 
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -260,6 +270,7 @@ Graph::Graph()
   this->set_defaults();
   this->_is_weighted = false;
   this->_correct_self_loops = false;
+  igraph_vector_init(&this->_temp_igraph_vector, this->vcount());
   this->init_admin();
   this->set_self_weights();
 }
@@ -401,8 +412,8 @@ void Graph::init_admin()
   for (size_t v = 0; v < n; v++)
     this->_total_size += this->node_size(v);
 
+  // this is initialized in the constructors
   igraph_vector_t *res = &this->_temp_igraph_vector;
-  igraph_vector_init(res, n);
 
   // Degree IN
   igraph_degree(this->_graph, res, igraph_vss_all(), IGRAPH_IN, true);

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -702,7 +702,7 @@ Graph* Graph::collapse_graph(MutableVertexPartition* partition)
   #endif
 
   size_t n_collapsed = partition->n_communities();
-  vector<vector<size_t>> community_memberships = partition->get_communities();
+  vector<vector<size_t> > community_memberships = partition->get_communities();
 
   vector<double> collapsed_weights;
   double total_collapsed_weight = 0.0;

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -364,6 +364,7 @@ void Graph::init_admin()
 {
 
   size_t m = this->ecount();
+  this->_is_directed = igraph_is_directed(this->_graph);
 
   // Determine total weight in the graph.
   this->_total_weight = 0.0;
@@ -630,7 +631,7 @@ size_t Graph::get_random_neighbour(size_t v, igraph_neimode_t mode, igraph_rng_t
   if (this->degree(v, mode) <= 0)
     throw Exception("Cannot select a random neighbour for an isolated node.");
 
-  if (igraph_is_directed(this->_graph) && mode != IGRAPH_ALL)
+  if (this->is_directed() && mode != IGRAPH_ALL)
   {
     if (mode == IGRAPH_OUT)
     {

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -382,8 +382,19 @@ void Graph::init_admin()
   this->_strength_in.clear();
   this->_strength_in.resize(n, 0.0);
 
-  this->_strength_out.clear();
-  this->_strength_out.resize(n, 0.0);
+  this->_degree_in.clear();
+  this->_degree_in.resize(n, 0.0);
+
+  if (this->_is_directed) {
+    this->_strength_out.clear();
+    this->_strength_out.resize(n, 0.0);
+
+    this->_degree_out.clear();
+    this->_degree_out.resize(n, 0);
+
+    this->_degree_all.clear();
+    this->_degree_all.resize(n, 0);
+  }
 
   // Determine total weight in the graph.
   this->_total_weight = 0.0;
@@ -397,10 +408,19 @@ void Graph::init_admin()
     if (this->is_directed()) {
       this->_strength_in[to] += w;
       this->_strength_out[from] += w;
+
+      this->_degree_in[to]++;
+      this->_degree_out[from]++;
+      this->_degree_all[to]++;
+      this->_degree_all[from]++;
     } else {
-      // we only compute strength_in for undirected graphs
+      // we only compute strength_in and degree_in for undirected graphs
       this->_strength_in[to] += w;
       this->_strength_in[from] += w;
+
+      // recall that igraph ignores the mode for undirected graphs
+      this->_degree_in[to]++;
+      this->_degree_in[from]++;
     }
   }
 
@@ -414,29 +434,6 @@ void Graph::init_admin()
 
   // this is initialized in the constructors
   igraph_vector_t *res = &this->_temp_igraph_vector;
-
-  // Degree IN
-  igraph_degree(this->_graph, res, igraph_vss_all(), IGRAPH_IN, true);
-  this->_degree_in.clear();
-  this->_degree_in.resize(n);
-  for (size_t v = 0; v < n; v++)
-    this->_degree_in[v] = VECTOR(*res)[v];
-
-  if (this->is_directed()) {
-    // Degree OUT
-    igraph_degree(this->_graph, res, igraph_vss_all(), IGRAPH_OUT, true);
-    this->_degree_out.clear();
-    this->_degree_out.resize(n);
-    for (size_t v = 0; v < n; v++)
-      this->_degree_out[v] = VECTOR(*res)[v];
-
-    // Degree ALL
-    igraph_degree(this->_graph, res, igraph_vss_all(), IGRAPH_ALL, true);
-    this->_degree_all.clear();
-    this->_degree_all.resize(n);
-    for (size_t v = 0; v < n; v++)
-      this->_degree_all[v] = VECTOR(*res)[v];
-  }
 
   // Calculate density;
   double w = this->total_weight();

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -539,13 +539,6 @@ vector<size_t> const& Graph::get_neighbour_edges(size_t v, igraph_neimode_t mode
   throw Exception("Incorrect model for getting neighbour edges.");
 }
 
-pair<size_t, size_t> Graph::get_endpoints(size_t e)
-{
-  igraph_integer_t from, to;
-  igraph_edge(this->_graph, e,&from, &to);
-  return make_pair<size_t, size_t>((size_t)from, (size_t)to);
-}
-
 void Graph::cache_neighbours(size_t v, igraph_neimode_t mode)
 {
   #ifdef DEBUG
@@ -723,13 +716,13 @@ Graph* Graph::collapse_graph(MutableVertexPartition* partition)
 
   vector< map<size_t, double> > collapsed_edge_weights(partition->n_communities());
 
-  igraph_integer_t v, u;
+  size_t v, u;
   for (size_t e = 0; e < m; e++)
   {
     double w = this->edge_weight(e);
-    igraph_edge(this->_graph, e, &v, &u);
-    size_t v_comm = partition->membership((size_t)v);
-    size_t u_comm = partition->membership((size_t)u);
+    this->edge(e, &v, &u);
+    size_t v_comm = partition->membership(v);
+    size_t u_comm = partition->membership(u);
     if (collapsed_edge_weights[v_comm].count(u_comm) > 0)
       collapsed_edge_weights[v_comm][u_comm] += w;
     else

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -164,9 +164,8 @@ void MutableVertexPartition::init_admin()
   size_t m = graph->ecount();
   for (size_t e = 0; e < m; e++)
   {
-    pair<size_t, size_t> endpoints = this->graph->get_endpoints(e);
-    size_t v = endpoints.first;
-    size_t u = endpoints.second;
+    size_t v, u;
+    this->graph->edge(e, &v, &u);
 
     size_t v_comm = this->_membership[v];
     size_t u_comm = this->_membership[u];

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -253,10 +253,21 @@ void MutableVertexPartition::renumber_communities()
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = this;
   vector<size_t> new_comm_id = MutableVertexPartition::comm_ids_by_decreasing_size(partitions);
-  this->rearrange_community_labels(new_comm_id);
+  this->relabel_communities(new_comm_id);
 }
 
-void MutableVertexPartition::rearrange_community_labels(vector<size_t> const& new_comm_id) {
+/****************************************************************************
+ Renumber the communities according to the new labels in new_comm_id.
+
+ This adjusts the internal bookkeeping as required, avoiding the more costly
+ setup required in init_admin(). In particular, this avoids recomputation of
+ weights in/from/to each community by simply assigning the previously
+ computed values to the new, relabeled communities.
+
+ For instance, a new_comm_id of <1, 2, 0> will change the labels such that
+ community 0 becomes 1, community 1 becomes 2, and community 2 becomes 0.
+*****************************************************************************/
+void MutableVertexPartition::relabel_communities(vector<size_t> const& new_comm_id) {
   if (this->_n_communities != new_comm_id.size()) {
     throw Exception("Problem swapping community labels. Mismatch between n_communities and new_comm_id vector.");
   }
@@ -445,7 +456,7 @@ void MutableVertexPartition::renumber_communities(map<size_t, size_t> const& mem
     }
   }
 
-  this->rearrange_community_labels(new_comm_id);
+  this->relabel_communities(new_comm_id);
 }
 
 void MutableVertexPartition::renumber_communities(vector<size_t> const& membership)

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -148,6 +148,12 @@ void MutableVertexPartition::init_admin()
   this->_current_node_cache_community_from = n + 1; this->_cached_weight_from_community.resize(this->_n_communities, 0);
   this->_current_node_cache_community_to = n + 1;   this->_cached_weight_to_community.resize(this->_n_communities, 0);
   this->_current_node_cache_community_all = n + 1;  this->_cached_weight_all_community.resize(this->_n_communities, 0);
+  this->_cached_neigh_comms_all.resize(n);
+
+  if (this->get_graph()->is_directed()) {
+    this->_cached_neigh_comms_from.resize(n);
+    this->_cached_neigh_comms_to.resize(n);
+  }
 
   this->_empty_communities.clear();
 
@@ -806,7 +812,6 @@ void MutableVertexPartition::cache_neigh_communities(size_t v, igraph_neimode_t 
 
   // Reset cached neighbours
   _cached_neighs_comms->clear();
-  _cached_neighs_comms->reserve(degree);
   for (size_t idx = 0; idx < degree; idx++)
   {
     size_t u = neighbours[idx];

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -263,26 +263,23 @@ void MutableVertexPartition::rearrange_community_labels(vector<size_t> const& ne
 
   size_t n = this->graph->vcount();
   size_t nbcomms = this->n_communities();
-  size_t new_nbcomms = nbcomms - this->_empty_communities.size();
 
   for (size_t i = 0; i < n; i++)
     this->_membership[i] = new_comm_id[this->_membership[i]];
 
-  vector<double> new_total_weight_in_comm(new_nbcomms, 0.0);
-  vector<double> new_total_weight_from_comm(new_nbcomms, 0.0);
-  vector<double> new_total_weight_to_comm(new_nbcomms, 0.0);
-  vector<size_t> new_csize(new_nbcomms, 0.0);
-  vector<size_t> new_cnodes(new_nbcomms, 0.0);
+  vector<double> new_total_weight_in_comm(nbcomms, 0.0);
+  vector<double> new_total_weight_from_comm(nbcomms, 0.0);
+  vector<double> new_total_weight_to_comm(nbcomms, 0.0);
+  vector<size_t> new_csize(nbcomms, 0.0);
+  vector<size_t> new_cnodes(nbcomms, 0.0);
 
   for (size_t c = 0; c < nbcomms; c++) {
     size_t new_c = new_comm_id[c];
-    if (new_c < new_nbcomms) {
-      new_total_weight_in_comm[new_c] = this->_total_weight_in_comm[c];
-      new_total_weight_from_comm[new_c] = this->_total_weight_from_comm[c];
-      new_total_weight_to_comm[new_c] = this->_total_weight_to_comm[c];
-      new_csize[new_c] = this->_csize[c];
-      new_cnodes[new_c] = this->_cnodes[c];
-    }
+    new_total_weight_in_comm[new_c] = this->_total_weight_in_comm[c];
+    new_total_weight_from_comm[new_c] = this->_total_weight_from_comm[c];
+    new_total_weight_to_comm[new_c] = this->_total_weight_to_comm[c];
+    new_csize[new_c] = this->_csize[c];
+    new_cnodes[new_c] = this->_cnodes[c];
   }
 
   this->_total_weight_in_comm = new_total_weight_in_comm;
@@ -291,7 +288,7 @@ void MutableVertexPartition::rearrange_community_labels(vector<size_t> const& ne
   this->_csize = new_csize;
   this->_cnodes = new_cnodes;
   this->_empty_communities.clear();
-  this->_n_communities = new_nbcomms;
+  this->update_n_communities();
 
   // invalidate cached weight vectors
   this->_current_node_cache_community_from = n + 1;

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -729,48 +729,6 @@ void MutableVertexPartition::from_partition(MutableVertexPartition* partition)
   this->init_admin();
 }
 
-/****************************************************************************
- Calculate what is the total weight going from a node to a community.
-
-    Parameters:
-      v      -- The node which to check.
-      comm   -- The community which to check.
-*****************************************************************************/
-double MutableVertexPartition::weight_to_comm(size_t v, size_t comm)
-{
-  if (this->_current_node_cache_community_to != v)
-  {
-    this->cache_neigh_communities(v, IGRAPH_OUT);
-    this->_current_node_cache_community_to = v;
-  }
-
-  if (comm < this->_cached_weight_to_community.size())
-    return this->_cached_weight_to_community[comm];
-  else
-    return 0.0;
-}
-
-/****************************************************************************
- Calculate what is the total weight going from a community to a node.
-
-    Parameters:
-      v      -- The node which to check.
-      comm   -- The community which to check.
-*****************************************************************************/
-double MutableVertexPartition::weight_from_comm(size_t v, size_t comm)
-{
-  if (this->_current_node_cache_community_from != v)
-  {
-    this->cache_neigh_communities(v, IGRAPH_IN);
-    this->_current_node_cache_community_from = v;
-  }
-
-  if (comm < this->_cached_weight_from_community.size())
-    return this->_cached_weight_from_community[comm];
-  else
-    return 0.0;
-}
-
 void MutableVertexPartition::cache_neigh_communities(size_t v, igraph_neimode_t mode)
 {
   // TODO: We can probably calculate at once the IN, OUT and ALL

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -840,6 +840,9 @@ void MutableVertexPartition::cache_neigh_communities(size_t v, igraph_neimode_t 
 
 vector<size_t> const& MutableVertexPartition::get_neigh_comms(size_t v, igraph_neimode_t mode)
 {
+  if (!this->get_graph()->is_directed())
+    mode = IGRAPH_ALL; // igraph ignores mode for undirected graphs
+
   switch (mode)
   {
     case IGRAPH_IN:

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -171,7 +171,7 @@ void MutableVertexPartition::init_admin()
   for (size_t e = 0; e < m; e++)
   {
     size_t v, u;
-    this->graph->edge(e, &v, &u);
+    this->graph->edge(e, v, u);
 
     size_t v_comm = this->_membership[v];
     size_t u_comm = this->_membership[u];

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -300,9 +300,9 @@ void MutableVertexPartition::rearrange_community_labels(vector<size_t> const& ne
   }
 
   // invalidate cached weight vectors
-  this->_current_node_cache_community_from = n + 1;
-  this->_current_node_cache_community_to = n + 1;
-  this->_current_node_cache_community_all = n + 1;
+  this->_current_node_cache_community_from = n + 1; this->_cached_weight_from_community.resize(nbcomms, 0);
+  this->_current_node_cache_community_to = n + 1;   this->_cached_weight_to_community.resize(nbcomms, 0);
+  this->_current_node_cache_community_all = n + 1;  this->_cached_weight_all_community.resize(nbcomms, 0);
 }
 
 vector<size_t> MutableVertexPartition::comm_ids_by_decreasing_size(vector<MutableVertexPartition*> partitions)

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -252,7 +252,7 @@ void MutableVertexPartition::renumber_communities()
 {
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = this;
-  vector<size_t> new_comm_id = MutableVertexPartition::comm_ids_by_decreasing_size(partitions);
+  vector<size_t> new_comm_id = MutableVertexPartition::rank_order_communities(partitions);
   this->relabel_communities(new_comm_id);
 }
 
@@ -352,7 +352,7 @@ void MutableVertexPartition::relabel_communities(vector<size_t> const& new_comm_
   #endif
 }
 
-vector<size_t> MutableVertexPartition::comm_ids_by_decreasing_size(vector<MutableVertexPartition*> partitions)
+vector<size_t> MutableVertexPartition::rank_order_communities(vector<MutableVertexPartition*> partitions)
 {
   size_t nb_layers = partitions.size();
   size_t nb_comms = partitions[0]->n_communities();

--- a/src/MutableVertexPartition.cpp
+++ b/src/MutableVertexPartition.cpp
@@ -303,6 +303,42 @@ void MutableVertexPartition::rearrange_community_labels(vector<size_t> const& ne
   this->_current_node_cache_community_from = n + 1; this->_cached_weight_from_community.resize(nbcomms, 0);
   this->_current_node_cache_community_to = n + 1;   this->_cached_weight_to_community.resize(nbcomms, 0);
   this->_current_node_cache_community_all = n + 1;  this->_cached_weight_all_community.resize(nbcomms, 0);
+
+  #ifdef DEBUG
+    if (this->_csize.size() < this->_n_communities ||
+        this->_cnodes.size() < this->_n_communities ||
+        this->_total_weight_in_comm.size() < this->_n_communities ||
+        this->_total_weight_to_comm.size() < this->_n_communities ||
+        this->_total_weight_from_comm.size() < this->_n_communities ||
+        this->_cached_weight_from_community.size() < this->_n_communities ||
+        this->_cached_weight_to_community.size() < this->_n_communities ||
+        this->_cached_weight_all_community.size() < this->_n_communities) {
+      cerr << "ERROR: MutableVertexPartition bookkeeping is too small after rearrange_community_labels." << endl;
+    }
+
+    this->init_admin();
+
+    for (size_t c = 0; c < this->_n_communities; c++) {
+      if (fabs(new_total_weight_in_comm[c] - this->_total_weight_in_comm[c]) > 1e-6 ||
+          fabs(new_total_weight_from_comm[c] - this->_total_weight_from_comm[c]) > 1e-6 ||
+          fabs(new_total_weight_to_comm[c] - this->_total_weight_to_comm[c]) > 1e-6 ||
+          new_csize[c] != this->_csize[c] ||
+          new_cnodes[c] != this->_cnodes[c]) {
+        cerr << "ERROR: MutableVertexPartition bookkeeping is incorrect after rearrange_community_labels." << endl;
+        cerr << "Community c has " << endl
+             << "total_weight_in_comm=" << new_total_weight_in_comm[c]
+             << " (should be " << this->_total_weight_in_comm[c] << ")" << endl
+             << "total_weight_from_comm=" << new_total_weight_from_comm[c]
+             << " (should be " << this->_total_weight_from_comm[c] << ")" << endl
+             << "total_weight_to_comm=" << new_total_weight_to_comm[c]
+             << " (should be " << this->_total_weight_to_comm[c] << ")" << endl
+             << "csize=" << new_csize[c]
+             << " (should be " << this->_csize[c] << ")" << endl
+             << "cnodes=" << new_cnodes[c]
+             << " (should be " << this->_cnodes[c] << ")" << endl;
+      }
+    }
+  #endif
 }
 
 vector<size_t> MutableVertexPartition::comm_ids_by_decreasing_size(vector<MutableVertexPartition*> partitions)

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -1,4 +1,5 @@
 #include "Optimiser.h"
+#include <stdio.h>
 
 /****************************************************************************
   Create a new Optimiser object
@@ -599,6 +600,9 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
 
       if (possible_improv > max_improv)
       {
+        printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
+        printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
+        printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
         max_comm = comm;
         max_improv = possible_improv;
       }
@@ -635,6 +639,9 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
         #endif
         if (possible_improv > max_improv)
         {
+          printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
+          printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
+          printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
           max_improv = possible_improv;
           max_comm = comm;
         }

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -600,9 +600,11 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
 
       if (possible_improv > max_improv)
       {
-        printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
-        printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
-        printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
+        if (n == 3) {
+          printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
+          printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
+          printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
+        }
         max_comm = comm;
         max_improv = possible_improv;
       }
@@ -639,9 +641,11 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
         #endif
         if (possible_improv > max_improv)
         {
-          printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
-          printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
-          printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
+          if (n == 3) {
+            printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
+            printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
+            printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
+          }
           max_improv = possible_improv;
           max_comm = comm;
         }

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -523,12 +523,13 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
   //       aggregating/collapsing the graph.
 
   vector<bool> comm_added(partitions[0]->n_communities(), false);
+  vector<size_t> comms;
 
   // As long as the queue is not empty
   while(!vertex_order.empty())
   {
     size_t v = vertex_order.front(); vertex_order.pop();
-    vector<size_t> comms;
+    comms.clear();
     Graph* graph = NULL;
     MutableVertexPartition* partition = NULL;
     // What is the current community of the node (this should be the same for all layers)
@@ -1186,6 +1187,7 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
   vector< vector<size_t> > constrained_comms = constrained_partition->get_communities();
 
   vector<bool> comm_added(partitions[0]->n_communities(), false);
+  vector<size_t> comms;
 
   // For each node
   for (vector<size_t>::iterator it = vertex_order.begin();
@@ -1198,7 +1200,7 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
 
     if (partitions[0]->cnodes(v_comm) == 1)
     {
-      vector<size_t> comms;
+      comms.clear();
       MutableVertexPartition* partition = NULL;
 
       if (consider_comms == ALL_COMMS)

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -553,8 +553,10 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
       /****************************ALL NEIGH COMMS*****************************/
       for (size_t layer = 0; layer < nb_layers; layer++)
       {
-        vector<size_t> const& neigh_comm_layer = partitions[layer]->get_neigh_comms(v, IGRAPH_ALL);
-        comms.insert(neigh_comm_layer.begin(), neigh_comm_layer.end());
+        for (size_t u : partitions[layer]->get_graph()->get_neighbours(v, IGRAPH_ALL)) {
+          size_t comm = partitions[layer]->membership(u);
+          comms.insert(comm);
+        }
       }
     }
     else if (consider_comms == RAND_COMM)
@@ -1209,8 +1211,12 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
           /****************************ALL NEIGH COMMS*****************************/
           for (size_t layer = 0; layer < nb_layers; layer++)
           {
-            set<size_t> neigh_comm_layer = partitions[layer]->get_neigh_comms(v, IGRAPH_ALL, constrained_partition->membership());
-            comms.insert(neigh_comm_layer.begin(), neigh_comm_layer.end());
+            for (size_t u : partitions[layer]->get_graph()->get_neighbours(v, IGRAPH_ALL)) {
+              if (constrained_partition->membership(v) == constrained_partition->membership(u)) {
+                size_t comm = partitions[layer]->membership(u);
+                comms.insert(comm);
+              }
+            }
           }
       }
       else if (consider_comms == RAND_COMM)

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -349,13 +349,13 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
   // where r is the number of communities. The exception is fixed
   // nodes which should keep the numbers of the original communities
   q = 0.0;
-  vector<size_t> membership = MutableVertexPartition::renumber_communities(partitions);
-  partitions[0]->set_membership(membership);
-  membership = partitions[0]->renumber_communities(original_fixed_memberships);
+  partitions[0]->renumber_communities();
+  partitions[0]->renumber_communities(original_fixed_memberships);
+  vector<size_t> const& membership = partitions[0]->membership();
   // We only renumber the communities for the first graph,
   // since the communities for the other graphs should just be equal
   // to the membership of the first graph.
-  for (size_t layer = 0; layer < nb_layers; layer++)
+  for (size_t layer = 1; layer < nb_layers; layer++)
   {
     partitions[layer]->set_membership(membership);
     q += partitions[layer]->quality()*layer_weights[layer];
@@ -703,8 +703,9 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
   }
 
   partitions[0]->renumber_communities();
-  vector<size_t> const& membership = partitions[0]->renumber_communities(original_fixed_memberships);
-  for (size_t layer = 0; layer < nb_layers; layer++)
+  partitions[0]->renumber_communities(original_fixed_memberships);
+  vector<size_t> const& membership = partitions[0]->membership();
+  for (size_t layer = 1; layer < nb_layers; layer++)
   {
     partitions[layer]->set_membership(membership);
     #ifdef DEBUG
@@ -903,8 +904,9 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
   }
 
   partitions[0]->renumber_communities();
-  vector<size_t> const& membership = partitions[0]->renumber_communities(original_fixed_memberships);
-  for (size_t layer = 0; layer < nb_layers; layer++)
+  partitions[0]->renumber_communities(original_fixed_memberships);
+  vector<size_t> const& membership = partitions[0]->membership();
+  for (size_t layer = 1; layer < nb_layers; layer++)
   {
     partitions[layer]->set_membership(membership);
     #ifdef DEBUG

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -1,5 +1,4 @@
 #include "Optimiser.h"
-#include <stdio.h>
 
 /****************************************************************************
   Create a new Optimiser object
@@ -600,11 +599,6 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
 
       if (possible_improv > max_improv)
       {
-        if (n == 3) {
-          printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
-          printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
-          printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
-        }
         max_comm = comm;
         max_improv = possible_improv;
       }
@@ -641,11 +635,6 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
         #endif
         if (possible_improv > max_improv)
         {
-          if (n == 3) {
-            printf("possible_improv=%g > max_improv=%g ?\n", possible_improv, max_improv);
-            printf("possible_improv=%a > max_improv=%a ?\n", possible_improv, max_improv);
-            printf("(gt=%d, eq=%d, lt=%d)\n", possible_improv > max_improv, possible_improv == max_improv, possible_improv < max_improv);
-          }
           max_improv = possible_improv;
           max_comm = comm;
         }


### PR DESCRIPTION
![leiden_runtimes](https://user-images.githubusercontent.com/14023456/87258313-9e556800-c470-11ea-8fbd-9e73d97cf66b.png)

I noticed that igraph's `community_leiden(objective_function="modularity")` was faster than this package and wanted to make the difference less significant.

I think most of the changes here should be fairly self-explanatory if you look at one commit at a time. Feel free to comment on or ask for clarification on the more complicated changes.

Up until the very last commit here, the changes are "RNG consistent" with your master branch. That is, the results should be exactly the same as the current code. For example,
```python
import igraph as ig
import leidenalg as la
from random import seed

seed(0)
G = ig.Graph.Erdos_Renyi(n=100, m=500, directed=True)

optimiser = la.Optimiser()
optimiser.set_rng_seed(0)
part = la.RBConfigurationVertexPartition(G)
optimiser.optimise_partition(part)
print(part.membership)
```
prints
```python
[2, 0, 3, 2, 0, 1, 1, 0, 2, 4, 0, 0, 1, 3, 1, 0, 2, 1, 4, 3, 2, 3, 0, 3, 1, 2, 2, 3, 1, 4, 0, 0, 0, 1, 1, 4, 4, 1, 1, 3, 0, 2, 3, 2, 3, 0, 0, 0, 0, 0, 3, 4, 3, 1, 1, 0, 2, 2, 0, 2, 2, 1, 4, 2, 1, 0, 2, 4, 0, 0, 1, 0, 0, 4, 1, 1, 0, 1, 4, 2, 2, 4, 0, 2, 0, 0, 0, 2, 0, 1, 2, 3, 1, 0, 2, 4, 3, 0, 1, 1]
```
in both versions.

The last commit replaces some set iteration (which iterates in value-sorted order for `size_t`) with vector iteration (which iterates in the order in which the node's neighbors appear in igraph). This doesn't change the underlying algorithm, but the new iteration order slightly changes the results for any given RNG seed.

There's definitely more work that can be done, especially since this only makes tweaks to code paths taken with the default Optimiser parameters, but I think this is good enough for consideration at this point.