### PR TITLE
Fix optimise_partition_multiplex() kwargs inconsistency

### DIFF
--- a/src/Optimiser.py
+++ b/src/Optimiser.py
@@ -287,7 +287,7 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def optimise_partition_multiplex(self, partitions, layer_weights=None, fixed_nodes=None, n_iterations=2):
+  def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2, fixed_nodes=None):
     """ Optimise the given partitions simultaneously.
 
     Parameters


### PR DESCRIPTION
This fixes https://github.com/vtraag/leidenalg/issues/41.

In fa3fa0b8060362ec188b576a24357d97cb216de1, @iosonofabio added a `fixed_nodes` keyword argument to `optimise_partition_multiplex` before the `n_iterations` argument. This PR changes the ordering of these two arguments to be consistent with `optimise_partition`.

That is, it fixes the argument ordering inconsistency between
https://github.com/vtraag/leidenalg/blob/5bdff65c446faccda9c996cc11b57965ba3ff222/src/Optimiser.py#L232
https://github.com/vtraag/leidenalg/blob/5bdff65c446faccda9c996cc11b57965ba3ff222/src/Optimiser.py#L290

Some of the Python code depended on the old ordering, for example
https://github.com/vtraag/leidenalg/blob/5bdff65c446faccda9c996cc11b57965ba3ff222/src/functions.py#L161
so in the current version `n_iterations` gets passed in as `fixed_nodes`, which causes the crash in https://github.com/vtraag/leidenalg/issues/41.