### PR TITLE
Correct CI for building on windows, keys changed on msys2.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,10 @@ before_build:
   - git submodule update --init --recursive
 
 install:
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy"
   - bash -lc "pacman --noconfirm -S zstd"


### PR DESCRIPTION
It turned out that some new maintainers became responsible for `msys2`, which was accompanied by a change in keys. See https://www.msys2.org/news/#2020-06-29-new-packagers for more details. This PR installs those keys, as instructed.