### PR TITLE
Simplified for-loops, made fixed membership more efficient/clear

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -21,7 +21,7 @@ calling :func:`~leidenalg.Optimiser.optimise_partition` on the provided
 partition.
 
 .. testsetup::
-   
+
    G = ig.Graph.Erdos_Renyi(100, p=5./100)
    partition = la.CPMVertexPartition(G)
 
@@ -35,7 +35,7 @@ partition:
 >>> G = ig.Graph.Erdos_Renyi(100, p=5./100)
 >>> partition = la.ModularityVertexPartition(G)
 >>> diff = 1
->>> while diff > 0: 
+>>> while diff > 0:
 ...   diff = optimiser.optimise_partition(partition)
 
 Even if a call to :func:`~leidenalg.Optimiser.optimise_partition` did not improve
@@ -67,7 +67,7 @@ The simpler Louvain algorithm aggregates the partition and repeats the
 emulate that:
 
 >>> partition = la.ModularityVertexPartition(G)
->>> while optimiser.move_nodes(partition) > 0: 
+>>> while optimiser.move_nodes(partition) > 0:
 ...   partition = partition.aggregate_partition()
 
 This summarises the whole Louvain algorithm in just three lines of code.
@@ -117,7 +117,7 @@ This package builds on a previous implementation of the Louvain algorithm in
 the difference between ``louvain-igraph`` and ``leidenalg``, we ran both
 algorithms for 10 iterations on a `Youtube network
 <https://snap.stanford.edu/data/com-Youtube.html>`_ of more than 1 million
-nodes and almost 3 million edges. 
+nodes and almost 3 million edges.
 
 .. image:: figures/speed.png
 
@@ -148,11 +148,11 @@ for both :math:`\gamma_1` and :math:`\gamma_2` then the partition is also
 optimal for all :math:`\gamma_1 \leq \gamma \leq \gamma_2`.
 
 Such a resolution profile can be constructed using the
-:class:`~leidenalg.Optimiser` object. 
+:class:`~leidenalg.Optimiser` object.
 
 >>> G = ig.Graph.Famous('Zachary')
 >>> optimiser = la.Optimiser()
->>> profile = optimiser.resolution_profile(G, la.CPMVertexPartition, 
+>>> profile = optimiser.resolution_profile(G, la.CPMVertexPartition,
 ...                                        resolution_range=(0,1))
 
 Plotting the resolution parameter versus the total number of internal edges we
@@ -168,7 +168,7 @@ any resolution parameter between ``profile[i].resolution_parameter`` and
 ``profile[i+1].resolution_parameter`` the partition at position ``i`` should be
 better. Of course, there will be some variations because
 :func:`~leidenalg.Optimiser.optimise_partition` will find partitions of varying
-quality. The change points can then also vary for different runs. 
+quality. The change points can then also vary for different runs.
 
 This function repeatedly calls :func:`~leidenalg.Optimiser.optimise_partition`
 and can therefore require a lot of time. Especially for resolution parameters
@@ -183,7 +183,7 @@ For example, perhaps we previously already ran the Leiden algorithm on some
 dataset, and did some analysis on the resulting partition. If we then gather new
 data, and in particular new nodes, it might be useful to keep the previous
 community assignments fixed, while only updating the community assignments for
-the new nodes. This can be done using the ``fixed_nodes`` argument of
+the new nodes. This can be done using the ``is_membership_fixed`` argument of
 :func:`~leidenalg.Optimiser.find_partition`, see [2]_ for some details.
 
 For example, suppose we previously detected ``partition`` for graph ``G``, which
@@ -197,8 +197,8 @@ We can then only update the community assignments for the new nodes as follows
 
 >>> new_partition = la.CPMVertexPartition(G2, new_membership,
 ...                                       resolution_parameter=partition.resolution_parameter)
-... fixed_nodes = [i < G.vcount() for i in range(G2.vcount())]
->>> diff = optimiser.optimise_partition(partition, fixed_nodes=fixed_nodes)
+... is_membership_fixed = [i < G.vcount() for i in range(G2.vcount())]
+>>> diff = optimiser.optimise_partition(partition, is_membership_fixed=is_membership_fixed)
 
 In this example we used :class:`~leidenalg.CPMVertexPartition`. but any other
 ``VertexPartition`` would work as well.

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <set>
 #include <exception>
-#include <queue>
+#include <deque>
 
 //#ifdef DEBUG
 #include <iostream>
@@ -18,11 +18,10 @@ class MutableVertexPartition;
 using std::vector;
 using std::pair;
 using std::set;
-using std::queue;
+using std::deque;
 using std::make_pair;
 
 vector<size_t> range(size_t n);
-queue<size_t> queue_range(size_t n);
 
 bool orderCSize(const size_t* A, const size_t* B);
 
@@ -32,10 +31,8 @@ double KLL(double q, double p);
 template <class T> T sum(vector<T> vec)
 {
   T sum_of_elems = T();
-  for(typename vector<T>::iterator it=vec.begin();
-      it!=vec.end();
-      it++)
-      sum_of_elems += *it;
+  for (T x : vec)
+      sum_of_elems += x;
   return sum_of_elems;
 };
 

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -4,14 +4,12 @@
 #include <string>
 #include "GraphHelper.h"
 #include <map>
-#include <set>
 #include <queue>
 #include <utility>
 #include <algorithm>
 
 using std::string;
 using std::map;
-using std::set;
 using std::make_pair;
 using std::pair;
 using std::sort;
@@ -77,7 +75,7 @@ class MutableVertexPartition
     inline Graph* get_graph() { return this->graph; };
 
     void renumber_communities();
-    void renumber_communities(map<size_t, size_t> const& original_fixed_membership);
+    void renumber_communities(vector<size_t> const& fixed_nodes, vector<size_t> const& fixed_membership);
     void renumber_communities(vector<size_t> const& new_membership);
     void set_membership(vector<size_t> const& new_membership);
     void relabel_communities(vector<size_t> const& new_comm_id);
@@ -94,7 +92,7 @@ class MutableVertexPartition
     inline double total_weight_in_comm(size_t comm)   { return comm < _n_communities ? this->_total_weight_in_comm[comm] : 0.0; };
     inline double total_weight_from_comm(size_t comm) { return comm < _n_communities ? this->_total_weight_from_comm[comm] : 0.0; };
     inline double total_weight_to_comm(size_t comm)   { return comm < _n_communities ? this->_total_weight_to_comm[comm] : 0.0; };
-    
+
     inline double total_weight_in_all_comms()         { return this->_total_weight_in_all_comms; };
     inline size_t total_possible_edges_in_all_comms() { return this->_total_possible_edges_in_all_comms; };
 
@@ -130,7 +128,7 @@ class MutableVertexPartition
     }
 
     vector<size_t> const& get_neigh_comms(size_t v, igraph_neimode_t);
-    set<size_t> get_neigh_comms(size_t v, igraph_neimode_t mode, vector<size_t> const& constrained_membership);
+    vector<size_t> get_neigh_comms(size_t v, igraph_neimode_t mode, vector<size_t> const& constrained_membership);
 
     // By delegating the responsibility for deleting the graph to the partition,
     // we no longer have to worry about deleting this graph.

--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -25,7 +25,7 @@ class Optimiser
   public:
     Optimiser();
     double optimise_partition(MutableVertexPartition* partition);
-    double optimise_partition(MutableVertexPartition* partition, vector<bool> const& fixed_nodes);
+    double optimise_partition(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed);
     template <class T> T* find_partition(Graph* graph);
     template <class T> T* find_partition(Graph* graph, double resolution_parameter);
 
@@ -33,20 +33,20 @@ class Optimiser
     // Each node will be in the same community in all graphs, and the graphs are expected to have identical nodes
     // Optionally we can loop over all possible communities instead of only the neighbours. In the case of negative
     // layer weights this may be necessary.
-    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& fixed_nodes);
+    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed);
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);
-    double move_nodes(MutableVertexPartition* partition, vector<bool> const& fixed_nodes, int consider_comms, bool renumber_fixed_nodes);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& fixed_nodes, bool renumber_fixed_nodes);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& fixed_nodes, int consider_comms, int consider_empty_community);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& fixed_nodes, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes);
+    double move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_is_membership_fixed);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_is_membership_fixed);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_is_membership_fixed);
 
     double merge_nodes(MutableVertexPartition* partition);
     double merge_nodes(MutableVertexPartition* partition, int consider_comms);
-    double merge_nodes(MutableVertexPartition* partition, vector<bool> const& fixed_nodes, int consider_comms, bool renumber_fixed_nodes);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& fixed_nodes, bool renumber_fixed_nodes);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& fixed_nodes, int consider_comms, bool renumber_fixed_nodes);
+    double merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_is_membership_fixed);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_is_membership_fixed);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_is_membership_fixed);
 
     double move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition);
     double move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition);

--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -37,16 +37,16 @@ class Optimiser
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);
-    double move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_is_membership_fixed);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_is_membership_fixed);
+    double move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_fixed_nodes);
     double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community);
-    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_is_membership_fixed);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes);
 
     double merge_nodes(MutableVertexPartition* partition);
     double merge_nodes(MutableVertexPartition* partition, int consider_comms);
-    double merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_is_membership_fixed);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_is_membership_fixed);
-    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_is_membership_fixed);
+    double merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_fixed_nodes);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes);
 
     double move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition);
     double move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition);

--- a/src/GraphHelper.cpp
+++ b/src/GraphHelper.cpp
@@ -8,16 +8,8 @@
 vector<size_t> range(size_t n)
 {
   vector<size_t> range_vec(n);
-  for(size_t i = 0; i<n; i++)
+  for(size_t i = 0; i < n; i++)
     range_vec[i] = i;
-  return range_vec;
-}
-
-queue<size_t> queue_range(size_t n)
-{
-  queue<size_t> range_vec;
-  for(size_t i = 0; i<n; i++)
-    range_vec.push(i);
   return range_vec;
 }
 

--- a/src/Optimiser.py
+++ b/src/Optimiser.py
@@ -229,7 +229,7 @@ class Optimiser(object):
     """
     _c_leiden._Optimiser_set_rng_seed(self._optimiser, value)
 
-  def optimise_partition(self, partition, n_iterations=2, fixed_nodes=None):
+  def optimise_partition(self, partition, n_iterations=2, is_membership_fixed=None):
     """ Optimise the given partition.
 
     Parameters
@@ -242,7 +242,7 @@ class Optimiser(object):
       are run. If the number of iterations is negative, the Leiden algorithm is
       run until an iteration in which there was no improvement.
 
-    fixed_nodes: list of bools or None
+    is_membership_fixed: list of bools or None
       Boolean list of nodes that are not allowed to change community. The
       length of this list must be equal to the number of nodes. By default
       (None) all nodes can change community during the optimization.
@@ -260,12 +260,12 @@ class Optimiser(object):
     >>> partition = la.ModularityVertexPartition(G)
     >>> diff = optimiser.optimise_partition(partition)
 
-    or, fixing some nodes:
+    or, fixing the membership of some nodes:
 
-    >>> fixed_nodes = [False for v in G.vs]
-    >>> fixed_nodes[4] = True
-    >>> fixed_nodes[6] = True
-    >>> diff = optimiser.optimise_partition(partition, fixed_nodes=fixed_nodes)
+    >>> is_membership_fixed = [False for v in G.vs]
+    >>> is_membership_fixed[4] = True
+    >>> is_membership_fixed[6] = True
+    >>> diff = optimiser.optimise_partition(partition, is_membership_fixed=is_membership_fixed)
     """
 
     itr = 0
@@ -275,7 +275,7 @@ class Optimiser(object):
       diff_inc = _c_leiden._Optimiser_optimise_partition(
               self._optimiser,
               partition._partition,
-              fixed_nodes=fixed_nodes,
+              is_membership_fixed=is_membership_fixed,
               )
       diff += diff_inc
       itr += 1
@@ -287,7 +287,7 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2, fixed_nodes=None):
+  def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2, is_membership_fixed=None):
     """ Optimise the given partitions simultaneously.
 
     Parameters
@@ -298,7 +298,7 @@ class Optimiser(object):
     layer_weights
       List of weights of layers.
 
-    fixed_nodes: list of bools or None
+    is_membership_fixed: list of bools or None
       Boolean list of nodes that are not allowed to change community. The
       length of this list must be equal to the number of nodes. By default
       (None) all nodes can change community during the optimization.
@@ -381,7 +381,7 @@ class Optimiser(object):
         self._optimiser,
         [partition._partition for partition in partitions],
         layer_weights,
-        fixed_nodes)
+        is_membership_fixed)
       diff += diff_inc
       itr += 1
       if n_iterations < 0:
@@ -393,7 +393,7 @@ class Optimiser(object):
       partition._update_internal_membership()
     return diff
 
-  def move_nodes(self, partition, fixed_nodes=None, consider_comms=None):
+  def move_nodes(self, partition, is_membership_fixed=None, consider_comms=None):
     """ Move nodes to alternative communities for *optimising* the partition.
 
     Parameters
@@ -401,7 +401,7 @@ class Optimiser(object):
     partition
       The partition for which to move nodes.
 
-    fixed_nodes: list of bools or None
+    is_membership_fixed: list of bools or None
       Boolean list of nodes that are not allowed to change community. The
       length of this list must be equal to the number of nodes. By default
       (None) all nodes can change community during the optimization.
@@ -439,7 +439,7 @@ class Optimiser(object):
     if (consider_comms is None):
       consider_comms = self.consider_comms
     diff = _c_leiden._Optimiser_move_nodes(
-            self._optimiser, partition._partition, fixed_nodes, consider_comms)
+            self._optimiser, partition._partition, is_membership_fixed, consider_comms)
     partition._update_internal_membership()
     return diff
 
@@ -492,7 +492,7 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def merge_nodes(self, partition, fixed_nodes=None, consider_comms=None):
+  def merge_nodes(self, partition, is_membership_fixed=None, consider_comms=None):
     """ Merge nodes for *optimising* the partition.
 
     Parameters
@@ -500,7 +500,7 @@ class Optimiser(object):
     partition
       The partition for which to merge nodes.
 
-    fixed_nodes: list of bools or None
+    is_membership_fixed: list of bools or None
       Boolean list of nodes that are not allowed to change community. The
       length of this list must be equal to the number of nodes. By default
       (None) all nodes can change community during the optimization.
@@ -537,7 +537,7 @@ class Optimiser(object):
     if (consider_comms is None):
       consider_comms = self.consider_comms
     diff = _c_leiden._Optimiser_merge_nodes(
-            self._optimiser, partition._partition, fixed_nodes, consider_comms)
+            self._optimiser, partition._partition, is_membership_fixed, consider_comms)
     partition._update_internal_membership()
     return diff
 

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -39,9 +39,9 @@ extern "C"
   {
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
-    PyObject* py_fixed_nodes = NULL;
+    PyObject* py_is_membership_fixed = NULL;
 
-    static char* kwlist[] = {"optimiser", "partition", "fixed_nodes", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
@@ -49,11 +49,11 @@ extern "C"
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|O", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_fixed_nodes))
+                                     &py_is_membership_fixed))
         return NULL;
 
     #ifdef DEBUG
-      cerr << "optimise_partition(" << py_partition << ", fixed_nodes=" << py_fixed_nodes << ");" << endl;
+      cerr << "optimise_partition(" << py_partition << ", is_membership_fixed=" << py_is_membership_fixed << ");" << endl;
     #endif
 
     #ifdef DEBUG
@@ -73,30 +73,30 @@ extern "C"
     #endif
 
     size_t n = partition->get_graph()->vcount();
-    vector<bool> fixed_nodes(n, false);
-    if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+    vector<bool> is_membership_fixed(n, false);
+    if (py_is_membership_fixed != NULL && py_is_membership_fixed != Py_None)
     {
       #ifdef DEBUG
-        cerr << "Reading fixed_nodes." << endl;
+        cerr << "Reading is_membership_fixed." << endl;
       #endif
 
-      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
-      if (nb_fixed_nodes != n)
+      size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
+      if (nb_is_membership_fixed != n)
       {
         throw Exception("Node size vector not the same size as the number of nodes.");
       }
 
       for (size_t v = 0; v < n; v++)
       {
-        PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
-        fixed_nodes[v] = PyObject_IsTrue(py_item);
+        PyObject* py_item = PyList_GetItem(py_is_membership_fixed, v);
+        is_membership_fixed[v] = PyObject_IsTrue(py_item);
       }
     }
 
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partition, fixed_nodes);
+      q = optimiser->optimise_partition(partition, is_membership_fixed);
     }
     catch (std::exception e)
     {
@@ -111,9 +111,9 @@ extern "C"
     PyObject* py_optimiser = NULL;
     PyObject* py_partitions = NULL;
     PyObject* py_layer_weights = NULL;
-    PyObject* py_fixed_nodes = NULL;
+    PyObject* py_is_membership_fixed = NULL;
 
-    static char* kwlist[] = {"optimiser", "partitions", "layer_weights", "fixed_nodes", NULL};
+    static char* kwlist[] = {"optimiser", "partitions", "layer_weights", "is_membership_fixed", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
@@ -121,7 +121,7 @@ extern "C"
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|O", kwlist,
                                      &py_optimiser, &py_partitions,
-                                     &py_layer_weights, &py_fixed_nodes))
+                                     &py_layer_weights, &py_is_membership_fixed))
         return NULL;
 
     size_t nb_partitions = PyList_Size(py_partitions);
@@ -174,23 +174,23 @@ extern "C"
       return NULL;
 
     size_t n = partitions[0]->get_graph()->vcount();
-    vector<bool> fixed_nodes(n, false);
-    if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+    vector<bool> is_membership_fixed(n, false);
+    if (py_is_membership_fixed != NULL && py_is_membership_fixed != Py_None)
     {
       #ifdef DEBUG
-        cerr << "Reading fixed_nodes." << endl;
+        cerr << "Reading is_membership_fixed." << endl;
       #endif
 
-      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
-      if (nb_fixed_nodes != n)
+      size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
+      if (nb_is_membership_fixed != n)
       {
         throw Exception("Node size vector not the same size as the number of nodes.");
       }
 
       for (size_t v = 0; v < n; v++)
       {
-        PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
-        fixed_nodes[v] = PyObject_IsTrue(py_item);
+        PyObject* py_item = PyList_GetItem(py_is_membership_fixed, v);
+        is_membership_fixed[v] = PyObject_IsTrue(py_item);
       }
     }
 
@@ -206,7 +206,7 @@ extern "C"
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partitions, layer_weights, fixed_nodes);
+      q = optimiser->optimise_partition(partitions, layer_weights, is_membership_fixed);
     }
     catch (std::exception e)
     {
@@ -220,10 +220,10 @@ extern "C"
   {
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
-    PyObject* py_fixed_nodes = NULL;
+    PyObject* py_is_membership_fixed = NULL;
     int consider_comms = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "fixed_nodes", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
@@ -231,7 +231,7 @@ extern "C"
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_fixed_nodes, &consider_comms))
+                                     &py_is_membership_fixed, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -255,23 +255,23 @@ extern "C"
     #endif
 
     size_t n = partition->get_graph()->vcount();
-    vector<bool> fixed_nodes(n, false);
-    if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+    vector<bool> is_membership_fixed(n, false);
+    if (py_is_membership_fixed != NULL && py_is_membership_fixed != Py_None)
     {
       #ifdef DEBUG
-        cerr << "Reading fixed_nodes." << endl;
+        cerr << "Reading is_membership_fixed." << endl;
       #endif
 
-      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
-      if (nb_fixed_nodes != n)
+      size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
+      if (nb_is_membership_fixed != n)
       {
         throw Exception("Node size vector not the same size as the number of nodes.");
       }
 
       for (size_t v = 0; v < n; v++)
       {
-        PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
-        fixed_nodes[v] = PyObject_IsTrue(py_item);
+        PyObject* py_item = PyList_GetItem(py_is_membership_fixed, v);
+        is_membership_fixed[v] = PyObject_IsTrue(py_item);
       }
     }
 
@@ -281,7 +281,7 @@ extern "C"
     double q  = 0.0;
     try
     {
-      q = optimiser->move_nodes(partition, fixed_nodes, consider_comms, true);
+      q = optimiser->move_nodes(partition, is_membership_fixed, consider_comms, true);
     }
     catch (std::exception e)
     {
@@ -295,10 +295,10 @@ extern "C"
   {
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
-    PyObject* py_fixed_nodes = NULL;
+    PyObject* py_is_membership_fixed = NULL;
     int consider_comms = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "fixed_nodes", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
@@ -306,7 +306,7 @@ extern "C"
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_fixed_nodes, &consider_comms))
+                                     &py_is_membership_fixed, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -330,23 +330,23 @@ extern "C"
     #endif
 
     size_t n = partition->get_graph()->vcount();
-    vector<bool> fixed_nodes(n, false);
-    if (py_fixed_nodes != NULL && py_fixed_nodes != Py_None)
+    vector<bool> is_membership_fixed(n, false);
+    if (py_is_membership_fixed != NULL && py_is_membership_fixed != Py_None)
     {
       #ifdef DEBUG
-        cerr << "Reading fixed_nodes." << endl;
+        cerr << "Reading is_membership_fixed." << endl;
       #endif
 
-      size_t nb_fixed_nodes = PyList_Size(py_fixed_nodes);
-      if (nb_fixed_nodes != n)
+      size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
+      if (nb_is_membership_fixed != n)
       {
         throw Exception("Node size vector not the same size as the number of nodes.");
       }
 
       for (size_t v = 0; v < n; v++)
       {
-        PyObject* py_item = PyList_GetItem(py_fixed_nodes, v);
-        fixed_nodes[v] = PyObject_IsTrue(py_item);
+        PyObject* py_item = PyList_GetItem(py_is_membership_fixed, v);
+        is_membership_fixed[v] = PyObject_IsTrue(py_item);
       }
     }
 
@@ -356,7 +356,7 @@ extern "C"
     double q = 0.0;
     try
     {
-      q = optimiser->merge_nodes(partition, fixed_nodes, consider_comms, true);
+      q = optimiser->merge_nodes(partition, is_membership_fixed, consider_comms, true);
     }
     catch (std::exception e)
     {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+if [ "$APPVEYOR_REPO_TAG" == "true" ]; then
+    echo "Uploading!"
+fi

--- a/tests/test_Optimiser.py
+++ b/tests/test_Optimiser.py
@@ -24,11 +24,11 @@ class OptimiserTest(unittest.TestCase):
   def test_move_nodes_with_fixed(self):
     # One edge plus singleton, but the two connected nodes are fixed
     G = ig.Graph([(0, 2)])
-    fixed_nodes = [True, False, True]
+    is_membership_fixed = [True, False, True]
     partition = leidenalg.CPMVertexPartition(
             G,
             resolution_parameter=0.1);
-    self.optimiser.move_nodes(partition, fixed_nodes=fixed_nodes, consider_comms=leidenalg.ALL_NEIGH_COMMS);
+    self.optimiser.move_nodes(partition, is_membership_fixed=is_membership_fixed, consider_comms=leidenalg.ALL_NEIGH_COMMS);
     self.assertListEqual(
         partition.sizes(), [1, 1, 1],
         msg="CPMVertexPartition(resolution_parameter=0.1) of one edge plus singleton after move nodes with fixed nodes is incorrect.");
@@ -66,7 +66,7 @@ class OptimiserTest(unittest.TestCase):
         partition.sizes(), 10*[10],
         msg="After optimising partition failed to find different components with CPMVertexPartition(resolution_parameter=0)");
 
-  def test_optimiser_with_fixed_nodes(self):
+  def test_optimiser_with_is_membership_fixed(self):
       G = ig.Graph.Full(3)
       partition = leidenalg.CPMVertexPartition(
               G,
@@ -74,9 +74,9 @@ class OptimiserTest(unittest.TestCase):
               initial_membership=[2, 1, 0])
       # Equivalent to setting initial membership
       #partition.set_membership([2, 1, 2])
-      fixed_nodes = [True, False, False]
+      is_membership_fixed = [True, False, False]
       original_quality = partition.quality()
-      diff = self.optimiser.optimise_partition(partition, fixed_nodes=fixed_nodes)
+      diff = self.optimiser.optimise_partition(partition, is_membership_fixed=is_membership_fixed)
       self.assertAlmostEqual(partition.quality() - original_quality, diff, places=10,
                              msg="Optimisation with fixed nodes returns inconsistent quality")
       self.assertListEqual(
@@ -84,7 +84,7 @@ class OptimiserTest(unittest.TestCase):
             msg="After optimising partition with fixed nodes failed to recover initial fixed memberships"
             )
 
-  def test_optimiser_fixed_nodes_large_labels(self):
+  def test_optimiser_is_membership_fixed_large_labels(self):
     G = ig.Graph.Erdos_Renyi(n=100, p=5./100, directed=True, loops=True)
 
     membership = list(range(G.vcount()))
@@ -92,11 +92,11 @@ class OptimiserTest(unittest.TestCase):
 
     # large enough to force nonconsecutive labels in the final partition
     fixed_node_idx = 90
-    fixed_nodes = [False] * G.vcount()
-    fixed_nodes[fixed_node_idx] = True
+    is_membership_fixed = [False] * G.vcount()
+    is_membership_fixed[fixed_node_idx] = True
 
     original_quality = partition.quality()
-    diff = self.optimiser.optimise_partition(partition, fixed_nodes=fixed_nodes)
+    diff = self.optimiser.optimise_partition(partition, is_membership_fixed=is_membership_fixed)
 
     self.assertLess(len(set(partition.membership)), len(partition),
                     msg="Optimisation with fixed nodes yielded too many communities")


### PR DESCRIPTION
All loops are simplified using range-based for-loops (only supported in C++11) where possible.

Some of the types were changed a bit, the `set` container was completely removed everywhere.

Additionally, some aspects around fixed membership are clarified (as identified in #43), making the terminology a bit more clear, and also making the implementation slightly faster.