### PR TITLE
Add max_comm_size to constrain the community size.

### DIFF
--- a/include/Optimiser.h
+++ b/include/Optimiser.h
@@ -26,6 +26,7 @@ class Optimiser
     Optimiser();
     double optimise_partition(MutableVertexPartition* partition);
     double optimise_partition(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed);
+    double optimise_partition(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, size_t max_comm_size);
     template <class T> T* find_partition(Graph* graph);
     template <class T> T* find_partition(Graph* graph, double resolution_parameter);
 
@@ -34,29 +35,38 @@ class Optimiser
     // Optionally we can loop over all possible communities instead of only the neighbours. In the case of negative
     // layer weights this may be necessary.
     double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed);
+    double optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, size_t max_comm_size);
 
     double move_nodes(MutableVertexPartition* partition);
     double move_nodes(MutableVertexPartition* partition, int consider_comms);
     double move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes);
+    double move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm_size);
     double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_fixed_nodes);
     double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community);
     double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes);
+    double move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes, size_t max_comm_size);
 
     double merge_nodes(MutableVertexPartition* partition);
     double merge_nodes(MutableVertexPartition* partition, int consider_comms);
     double merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes);
+    double merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm_size);
     double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, bool renumber_fixed_nodes);
     double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes);
+    double merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm_size);
 
     double move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition);
     double move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition);
+    double move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size);
     double move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, MutableVertexPartition* constrained_partition);
     double move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition);
+    double move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size);
 
     double merge_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition);
     double merge_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition);
+    double merge_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size);
     double merge_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, MutableVertexPartition* constrained_partition);
     double merge_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition);
+    double merge_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size);
 
     inline void set_rng_seed(size_t seed) { igraph_rng_seed(&rng, seed); };
 
@@ -68,6 +78,7 @@ class Optimiser
     int optimise_routine; // What routine to use for optimisation
     int refine_routine; // What routine to use for optimisation
     int consider_empty_community; // Determine whether to consider moving nodes to an empty community
+    size_t max_comm_size; // Constrain the maximal community size.
 
     static const int ALL_COMMS = 1;       // Consider all communities for improvement.
     static const int ALL_NEIGH_COMMS = 2; // Consider all neighbour communities for improvement.

--- a/include/pynterface.h
+++ b/include/pynterface.h
@@ -71,6 +71,7 @@ extern "C"
       {"_Optimiser_set_refine_routine",             (PyCFunction)_Optimiser_set_refine_routine,             METH_VARARGS | METH_KEYWORDS, ""},
       {"_Optimiser_set_consider_empty_community",   (PyCFunction)_Optimiser_set_consider_empty_community,   METH_VARARGS | METH_KEYWORDS, ""},
       {"_Optimiser_set_refine_partition",           (PyCFunction)_Optimiser_set_refine_partition,           METH_VARARGS | METH_KEYWORDS, ""},
+      {"_Optimiser_set_max_comm_size",              (PyCFunction)_Optimiser_set_max_comm_size,              METH_VARARGS | METH_KEYWORDS, ""},
 
       {"_Optimiser_get_consider_comms",             (PyCFunction)_Optimiser_get_consider_comms,             METH_VARARGS | METH_KEYWORDS, ""},
       {"_Optimiser_get_refine_consider_comms",      (PyCFunction)_Optimiser_get_refine_consider_comms,      METH_VARARGS | METH_KEYWORDS, ""},
@@ -78,6 +79,7 @@ extern "C"
       {"_Optimiser_get_refine_routine",             (PyCFunction)_Optimiser_get_refine_routine,             METH_VARARGS | METH_KEYWORDS, ""},
       {"_Optimiser_get_consider_empty_community",   (PyCFunction)_Optimiser_get_consider_empty_community,   METH_VARARGS | METH_KEYWORDS, ""},
       {"_Optimiser_get_refine_partition",           (PyCFunction)_Optimiser_get_refine_partition,           METH_VARARGS | METH_KEYWORDS, ""},
+      {"_Optimiser_get_max_comm_size",              (PyCFunction)_Optimiser_get_max_comm_size,              METH_VARARGS | METH_KEYWORDS, ""},
 
       {"_Optimiser_set_rng_seed",                   (PyCFunction)_Optimiser_set_rng_seed,                   METH_VARARGS | METH_KEYWORDS, ""},
 

--- a/include/python_optimiser_interface.h
+++ b/include/python_optimiser_interface.h
@@ -45,6 +45,7 @@ extern "C"
   PyObject* _Optimiser_set_refine_routine(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _Optimiser_set_consider_empty_community(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _Optimiser_set_refine_partition(PyObject *self, PyObject *args, PyObject *keywds);
+  PyObject* _Optimiser_set_max_comm_size(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _Optimiser_set_rng_seed(PyObject *self, PyObject *args, PyObject *keywds);
 
   PyObject* _Optimiser_get_consider_comms(PyObject *self, PyObject *args, PyObject *keywds);
@@ -53,6 +54,7 @@ extern "C"
   PyObject* _Optimiser_get_refine_routine(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _Optimiser_get_consider_empty_community(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _Optimiser_get_refine_partition(PyObject *self, PyObject *args, PyObject *keywds);
+  PyObject* _Optimiser_get_max_comm_size(PyObject *self, PyObject *args, PyObject *keywds);
 
 #ifdef __cplusplus
 }

--- a/include/python_partition_interface.h
+++ b/include/python_partition_interface.h
@@ -27,7 +27,6 @@
 MutableVertexPartition* create_partition(Graph* graph, char* method, vector<size_t>* initial_membership, double resolution_parameter);
 MutableVertexPartition* create_partition_from_py(PyObject* py_obj_graph, char* method, PyObject* py_initial_membership, PyObject* py_weights, PyObject* py_node_sizes, double resolution_parameter);
 
-Graph* create_graph_from_py(PyObject* py_obj_graph);
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes);
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights);
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, int check_positive_weight);

--- a/include/python_partition_interface.h
+++ b/include/python_partition_interface.h
@@ -28,10 +28,9 @@ MutableVertexPartition* create_partition(Graph* graph, char* method, vector<size
 MutableVertexPartition* create_partition_from_py(PyObject* py_obj_graph, char* method, PyObject* py_initial_membership, PyObject* py_weights, PyObject* py_node_sizes, double resolution_parameter);
 
 Graph* create_graph_from_py(PyObject* py_obj_graph);
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights);
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights, int check_positive_weight);
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights, PyObject* py_node_sizes);
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights, PyObject* py_node_sizes, int check_positive_weight);
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes);
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights);
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, int check_positive_weight);
 
 PyObject* capsule_MutableVertexPartition(MutableVertexPartition* partition);
 MutableVertexPartition* decapsule_MutableVertexPartition(PyObject* py_partition);

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -630,7 +630,7 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
     #endif
 
     size_t max_comm = v_comm;
-    double max_improv = 0.0;
+    double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 0;
     size_t v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
@@ -910,7 +910,7 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
       #endif
 
       size_t max_comm = v_comm;
-      double max_improv = 0.0;
+      double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 0;
       size_t v_size = graphs[0]->node_size(v);
       for (size_t comm : comms)
       {
@@ -1136,7 +1136,7 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
     #endif
 
     size_t max_comm = v_comm;
-    double max_improv = 0.0;
+    double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 0;
     size_t v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
@@ -1371,7 +1371,7 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
       #endif
 
       size_t max_comm = v_comm;
-      double max_improv = 0.0;
+      double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 0;
       size_t v_size = graphs[0]->node_size(v);
       for (size_t comm : comms)
       {

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -28,6 +28,7 @@ Optimiser::Optimiser()
   this->refine_routine = Optimiser::MERGE_NODES;
   this->refine_partition = true;
   this->consider_empty_community = true;
+  this->max_comm_size = 0;
 
   igraph_rng_init(&rng, &igraph_rngtype_mt19937);
   igraph_rng_seed(&rng, rand());
@@ -56,10 +57,20 @@ double Optimiser::optimise_partition(MutableVertexPartition* partition)
 
 double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed)
 {
+  return this->optimise_partition(partition, is_membership_fixed, this->max_comm_size);
+}
+
+double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, size_t max_comm_size)
+{
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->optimise_partition(partitions, layer_weights, is_membership_fixed);
+  return this->optimise_partition(partitions, layer_weights, is_membership_fixed, max_comm_size);
+}
+
+double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed)
+{
+  return this->optimise_partition(partitions, layer_weights, is_membership_fixed, this->max_comm_size);
 }
 
 /*****************************************************************************
@@ -70,10 +81,10 @@ double Optimiser::optimise_partition(MutableVertexPartition* partition, vector<b
 /*****************************************************************************
   optimise the provided partition.
 *****************************************************************************/
-double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed)
+double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, size_t max_comm_size)
 {
   #ifdef DEBUG
-    cerr << "void Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed)" << endl;
+    cerr << "void Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, size_t max_comm_size)" << endl;
   #endif
 
   double q = 0.0;
@@ -142,9 +153,10 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
       cerr << "Quality before moving " <<  q << endl;
     #endif
     if (this->optimise_routine == Optimiser::MOVE_NODES)
-      improv += this->move_nodes(collapsed_partitions, layer_weights, is_collapsed_membership_fixed, false);
+      improv += this->move_nodes(collapsed_partitions, layer_weights, is_collapsed_membership_fixed, this->consider_comms, this->consider_empty_community, false, max_comm_size);
+
     else if (this->optimise_routine == Optimiser::MERGE_NODES)
-      improv += this->merge_nodes(collapsed_partitions, layer_weights, is_collapsed_membership_fixed, false);
+      improv += this->merge_nodes(collapsed_partitions, layer_weights, is_collapsed_membership_fixed, this->consider_comms, false, max_comm_size);
 
     #ifdef DEBUG
       cerr << "Found " << collapsed_partitions[0]->n_communities() << " communities, improved " << improv << endl;
@@ -205,9 +217,9 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
         cerr << "\tStarting refinement with " << sub_collapsed_partitions[0]->n_communities() << " communities." << endl;
       #endif
       if (this->refine_routine == Optimiser::MOVE_NODES)
-        this->move_nodes_constrained(sub_collapsed_partitions, layer_weights, refine_consider_comms, collapsed_partitions[0]);
+        this->move_nodes_constrained(sub_collapsed_partitions, layer_weights, refine_consider_comms, collapsed_partitions[0], max_comm_size);
       else if (this->refine_routine == Optimiser::MERGE_NODES)
-        this->merge_nodes_constrained(sub_collapsed_partitions, layer_weights, refine_consider_comms, collapsed_partitions[0]);
+        this->merge_nodes_constrained(sub_collapsed_partitions, layer_weights, refine_consider_comms, collapsed_partitions[0], max_comm_size);
       #ifdef DEBUG
         cerr << "\tAfter applying refinement found " << sub_collapsed_partitions[0]->n_communities() << " communities." << endl;
       #endif
@@ -383,10 +395,15 @@ double Optimiser::move_nodes(MutableVertexPartition* partition, int consider_com
 
 double Optimiser::move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes)
 {
+  return this->move_nodes(partition, is_membership_fixed, consider_comms, renumber_fixed_nodes, this->max_comm_size);
+}
+
+double Optimiser::move_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm_size)
+{
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->move_nodes(partitions, layer_weights, is_membership_fixed, consider_comms, this->consider_empty_community, renumber_fixed_nodes);
+  return this->move_nodes(partitions, layer_weights, is_membership_fixed, consider_comms, this->consider_empty_community, renumber_fixed_nodes, max_comm_size);
 }
 
 double Optimiser::merge_nodes(MutableVertexPartition* partition)
@@ -402,10 +419,15 @@ double Optimiser::merge_nodes(MutableVertexPartition* partition, int consider_co
 
 double Optimiser::merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes)
 {
+  return this->merge_nodes(partition, is_membership_fixed, consider_comms, renumber_fixed_nodes, this->max_comm_size);
+}
+
+double Optimiser::merge_nodes(MutableVertexPartition* partition, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm_size)
+{
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->merge_nodes(partitions, layer_weights, is_membership_fixed, consider_comms, renumber_fixed_nodes);
+  return this->merge_nodes(partitions, layer_weights, is_membership_fixed, consider_comms, renumber_fixed_nodes, max_comm_size);
 }
 
 double Optimiser::move_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition)
@@ -415,10 +437,15 @@ double Optimiser::move_nodes_constrained(MutableVertexPartition* partition, Muta
 
 double Optimiser::move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition)
 {
+  return this->move_nodes_constrained(partition, consider_comms, constrained_partition, this->max_comm_size);
+}
+
+double Optimiser::move_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size)
+{
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->move_nodes_constrained(partitions, layer_weights, consider_comms, constrained_partition);
+  return this->move_nodes_constrained(partitions, layer_weights, consider_comms, constrained_partition, max_comm_size);
 }
 
 double Optimiser::merge_nodes_constrained(MutableVertexPartition* partition, MutableVertexPartition* constrained_partition)
@@ -428,10 +455,15 @@ double Optimiser::merge_nodes_constrained(MutableVertexPartition* partition, Mut
 
 double Optimiser::merge_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition)
 {
+  return this->merge_nodes_constrained(partition, consider_comms, constrained_partition, this->max_comm_size);
+}
+
+double Optimiser::merge_nodes_constrained(MutableVertexPartition* partition, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size)
+{
   vector<MutableVertexPartition*> partitions(1);
   partitions[0] = partition;
   vector<double> layer_weights(1, 1.0);
-  return this->merge_nodes_constrained(partitions, layer_weights, consider_comms, constrained_partition);
+  return this->merge_nodes_constrained(partitions, layer_weights, consider_comms, constrained_partition, max_comm_size);
 }
 
 /*****************************************************************************
@@ -459,8 +491,13 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
 
 double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes)
 {
+    return this->move_nodes(partitions, layer_weights, is_membership_fixed, consider_comms, consider_empty_community, renumber_fixed_nodes, this->max_comm_size);
+}
+
+double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes, size_t max_comm_size)
+{
   #ifdef DEBUG
-    cerr << "double Optimiser::move_nodes_multiplex(vector<MutableVertexPartition*> partitions, vector<double> weights)" << endl;
+    cerr << "double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, int consider_empty_community, bool renumber_fixed_nodes, size_t max_comm_size)" << endl;
   #endif
   // Number of multiplex layers
   size_t nb_layers = partitions.size();
@@ -605,6 +642,11 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
       {
         graph = graphs[layer];
         partition = partitions[layer];
+        // Do not create too-large communities.
+        if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
+          possible_improv = -1.0;
+          break;
+        }
         // Make sure to multiply it by the weight per layer
         possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
       }
@@ -736,8 +778,13 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
 
 double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes)
 {
+  return this->merge_nodes(partitions, layer_weights, is_membership_fixed, consider_comms, renumber_fixed_nodes, this->max_comm_size);
+}
+
+double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm_size)
+{
   #ifdef DEBUG
-    cerr << "double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> weights)" << endl;
+    cerr << "double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<bool> const& is_membership_fixed, int consider_comms, bool renumber_fixed_nodes, size_t max_comm)" << std::endl;
   #endif
 
   // Number of multiplex layers
@@ -799,10 +846,11 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
       cerr << "Consider moving node " << v << " from " << v_comm << "." << endl;
     #endif
 
+    Graph *graph = NULL;
+    MutableVertexPartition* partition = NULL;
+
     if (partitions[0]->cnodes(v_comm) == 1)
     {
-      MutableVertexPartition* partition = NULL;
-
       if (consider_comms == ALL_COMMS)
       {
         for(size_t comm = 0; comm < partitions[0]->n_communities(); comm++)
@@ -873,7 +921,13 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
         // Consider the improvement of moving to a community for all layers
         for (size_t layer = 0; layer < nb_layers; layer++)
         {
+          graph = graphs[layer];
           partition = partitions[layer];
+          // Do not create too-large communities.
+          if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
+            possible_improv = -1.0;
+            break;
+          }
           // Make sure to multiply it by the weight per layer
           possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
         }
@@ -955,8 +1009,13 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
 
 double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition)
 {
+  return this->move_nodes_constrained(partitions, layer_weights, refine_consider_comms, constrained_partition, this->max_comm_size);
+}
+
+double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size)
+{
   #ifdef DEBUG
-    cerr << "double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, vector<size_t> const& constrained_membership)" << endl;
+    cerr << "double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size)" << std::endl;
   #endif
   // Number of multiplex layers
   size_t nb_layers = partitions.size();
@@ -1092,6 +1151,11 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
       {
         graph = graphs[layer];
         partition = partitions[layer];
+        // Do not create too-large communities.
+        if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
+          possible_improv = -1.0;
+          break;
+        }
         // Make sure to multiply it by the weight per layer
         possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
       }
@@ -1187,8 +1251,13 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
 
 double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition)
 {
+  return this->merge_nodes_constrained(partitions, layer_weights, refine_consider_comms, constrained_partition, this->max_comm_size);
+}
+
+double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size)
+{
   #ifdef DEBUG
-    cerr << "double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector<double> weights)" << endl;
+    cerr << "double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partitions, vector<double> layer_weights, int consider_comms, MutableVertexPartition* constrained_partition, size_t max_comm_size)" << std::endl;
   #endif
 
   // Number of multiplex layers
@@ -1237,6 +1306,7 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
         comm_added[comm] = false;
       comms.clear();
 
+      Graph* graph = NULL;
       MutableVertexPartition* partition = NULL;
 
       if (consider_comms == ALL_COMMS)
@@ -1320,7 +1390,13 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
         // Consider the improvement of moving to a community for all layers
         for (size_t layer = 0; layer < nb_layers; layer++)
         {
+          graph = graphs[layer];
           partition = partitions[layer];
+          // Do not create too-large communities.
+          if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
+            possible_improv = -1.0;
+            break;
+          }
           // Make sure to multiply it by the weight per layer
           possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
         }

--- a/src/Optimiser.cpp
+++ b/src/Optimiser.cpp
@@ -631,24 +631,24 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
 
     size_t max_comm = v_comm;
     double max_improv = 0.0;
+    size_t v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
       // reset comm_added to all false
       comm_added[comm] = false;
+
+      // Do not create too-large communities.
+      if (0 < max_comm_size && max_comm_size < partitions[0]->csize(comm) + v_size) {
+        continue;
+      }
+
       double possible_improv = 0.0;
 
       // Consider the improvement of moving to a community for all layers
       for (size_t layer = 0; layer < nb_layers; layer++)
       {
-        graph = graphs[layer];
-        partition = partitions[layer];
-        // Do not create too-large communities.
-        if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
-          possible_improv = -1.0;
-          break;
-        }
         // Make sure to multiply it by the weight per layer
-        possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
+        possible_improv += layer_weights[layer]*partitions[layer]->diff_move(v, comm);
       }
 
       if (possible_improv > max_improv)
@@ -846,9 +846,6 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
       cerr << "Consider moving node " << v << " from " << v_comm << "." << endl;
     #endif
 
-    Graph *graph = NULL;
-    MutableVertexPartition* partition = NULL;
-
     if (partitions[0]->cnodes(v_comm) == 1)
     {
       if (consider_comms == ALL_COMMS)
@@ -914,22 +911,21 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
 
       size_t max_comm = v_comm;
       double max_improv = 0.0;
+      size_t v_size = graphs[0]->node_size(v);
       for (size_t comm : comms)
       {
+        // Do not create too-large communities.
+        if (0 < max_comm_size && max_comm_size < partitions[0]->csize(comm) + v_size) {
+          continue;
+        }
+
         double possible_improv = 0.0;
 
         // Consider the improvement of moving to a community for all layers
         for (size_t layer = 0; layer < nb_layers; layer++)
         {
-          graph = graphs[layer];
-          partition = partitions[layer];
-          // Do not create too-large communities.
-          if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
-            possible_improv = -1.0;
-            break;
-          }
           // Make sure to multiply it by the weight per layer
-          possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
+          possible_improv += layer_weights[layer]*partitions[layer]->diff_move(v, comm);
         }
         #ifdef DEBUG
           cerr << "Improvement of " << possible_improv << " when move to " << comm << "." << endl;
@@ -1141,23 +1137,21 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
 
     size_t max_comm = v_comm;
     double max_improv = 0.0;
-
+    size_t v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
+      // Do not create too-large communities.
+      if (0 < max_comm_size && max_comm_size < partitions[0]->csize(comm) + v_size) {
+        continue;
+      }
+
       double possible_improv = 0.0;
 
       // Consider the improvement of moving to a community for all layers
       for (size_t layer = 0; layer < nb_layers; layer++)
       {
-        graph = graphs[layer];
-        partition = partitions[layer];
-        // Do not create too-large communities.
-        if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
-          possible_improv = -1.0;
-          break;
-        }
         // Make sure to multiply it by the weight per layer
-        possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
+        possible_improv += layer_weights[layer]*partitions[layer]->diff_move(v, comm);
       }
 
       // Check if improvement is best
@@ -1306,9 +1300,6 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
         comm_added[comm] = false;
       comms.clear();
 
-      Graph* graph = NULL;
-      MutableVertexPartition* partition = NULL;
-
       if (consider_comms == ALL_COMMS)
       {
           // Add all communities to the set comms that are within the constrained community.
@@ -1381,24 +1372,24 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
 
       size_t max_comm = v_comm;
       double max_improv = 0.0;
+      size_t v_size = graphs[0]->node_size(v);
       for (size_t comm : comms)
       {
         // reset comm_added to all false
         comm_added[comm] = false;
+
+        // Do not create too-large communities.
+        if (0 < max_comm_size && max_comm_size < partitions[0]->csize(comm) + v_size) {
+          continue;
+        }
+
         double possible_improv = 0.0;
 
         // Consider the improvement of moving to a community for all layers
         for (size_t layer = 0; layer < nb_layers; layer++)
         {
-          graph = graphs[layer];
-          partition = partitions[layer];
-          // Do not create too-large communities.
-          if (0 < max_comm_size && max_comm_size < partition->csize(comm) + graph->node_size(v)) {
-            possible_improv = -1.0;
-            break;
-          }
           // Make sure to multiply it by the weight per layer
-          possible_improv += layer_weights[layer]*partition->diff_move(v, comm);
+          possible_improv += layer_weights[layer]*partitions[layer]->diff_move(v, comm);
         }
 
         if (possible_improv >= max_improv)

--- a/src/Optimiser.py
+++ b/src/Optimiser.py
@@ -217,6 +217,22 @@ class Optimiser(object):
   def consider_empty_community(self, value):
     _c_leiden._Optimiser_set_consider_empty_community(self._optimiser, value)
 
+  #########################################################3
+  # max_comm_size
+  @property
+  def max_comm_size(self):
+    """ Constrain the maximal community size.
+
+    By default (zero), communities can be of any size. If this is set to a
+    positive integer value, then communities will be constrained to be at most
+    this total size.
+    """
+    return _c_leiden._Optimiser_get_max_comm_size(self._optimiser)
+
+  @max_comm_size.setter
+  def max_comm_size(self, value):
+    _c_leiden._Optimiser_set_max_comm_size(self._optimiser, value)
+
   ##########################################################
   # Set rng seed
   def set_rng_seed(self, value):
@@ -229,7 +245,7 @@ class Optimiser(object):
     """
     _c_leiden._Optimiser_set_rng_seed(self._optimiser, value)
 
-  def optimise_partition(self, partition, n_iterations=2, is_membership_fixed=None):
+  def optimise_partition(self, partition, n_iterations=2, is_membership_fixed=None, max_comm_size=None):
     """ Optimise the given partition.
 
     Parameters
@@ -246,6 +262,10 @@ class Optimiser(object):
       Boolean list of nodes that are not allowed to change community. The
       length of this list must be equal to the number of nodes. By default
       (None) all nodes can change community during the optimization.
+
+    max_comm_size : int or None
+      Maximal total size of nodes in a community. If zero, then communities can
+      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -268,6 +288,9 @@ class Optimiser(object):
     >>> diff = optimiser.optimise_partition(partition, is_membership_fixed=is_membership_fixed)
     """
 
+    if max_comm_size is None:
+        max_comm_size = self.max_comm_size
+
     itr = 0
     diff = 0
     continue_iteration = itr < n_iterations or n_iterations < 0
@@ -276,6 +299,7 @@ class Optimiser(object):
               self._optimiser,
               partition._partition,
               is_membership_fixed=is_membership_fixed,
+              max_comm_size=max_comm_size,
               )
       diff += diff_inc
       itr += 1
@@ -287,7 +311,7 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2, is_membership_fixed=None):
+  def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2, is_membership_fixed=None, max_comm_size=None):
     """ Optimise the given partitions simultaneously.
 
     Parameters
@@ -307,6 +331,10 @@ class Optimiser(object):
       Number of iterations to run the Leiden algorithm. By default, 2 iterations
       are run. If the number of iterations is negative, the Leiden algorithm is
       run until an iteration in which there was no improvement.
+
+    max_comm_size : int or None
+      Maximal total size of nodes in a community. If zero, then communities can
+      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -373,6 +401,9 @@ class Optimiser(object):
     if not layer_weights:
       layer_weights = [1]*len(partitions)
 
+    if max_comm_size is None:
+        max_comm_size = self.max_comm_size
+
     itr = 0
     diff = 0
     continue_iteration = itr < n_iterations or n_iterations < 0
@@ -381,7 +412,8 @@ class Optimiser(object):
         self._optimiser,
         [partition._partition for partition in partitions],
         layer_weights,
-        is_membership_fixed)
+        is_membership_fixed,
+        max_comm_size)
       diff += diff_inc
       itr += 1
       if n_iterations < 0:
@@ -393,7 +425,7 @@ class Optimiser(object):
       partition._update_internal_membership()
     return diff
 
-  def move_nodes(self, partition, is_membership_fixed=None, consider_comms=None):
+  def move_nodes(self, partition, is_membership_fixed=None, consider_comms=None, max_comm_size=None):
     """ Move nodes to alternative communities for *optimising* the partition.
 
     Parameters
@@ -409,6 +441,10 @@ class Optimiser(object):
     consider_comms
       If ``None`` uses :attr:`consider_comms`, but can be set to
       something else.
+
+    max_comm_size : int or None
+      Maximal total size of nodes in a community. If zero, then communities can
+      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -438,8 +474,12 @@ class Optimiser(object):
     """
     if (consider_comms is None):
       consider_comms = self.consider_comms
+
+    if max_comm_size is None:
+        max_comm_size = self.max_comm_size
+
     diff = _c_leiden._Optimiser_move_nodes(
-            self._optimiser, partition._partition, is_membership_fixed, consider_comms)
+            self._optimiser, partition._partition, is_membership_fixed, consider_comms, max_comm_size)
     partition._update_internal_membership()
     return diff
 
@@ -492,7 +532,7 @@ class Optimiser(object):
     partition._update_internal_membership()
     return diff
 
-  def merge_nodes(self, partition, is_membership_fixed=None, consider_comms=None):
+  def merge_nodes(self, partition, is_membership_fixed=None, consider_comms=None, max_comm_size=None):
     """ Merge nodes for *optimising* the partition.
 
     Parameters
@@ -508,6 +548,10 @@ class Optimiser(object):
     consider_comms
       If ``None`` uses :attr:`consider_comms`, but can be set to
       something else.
+
+    max_comm_size : int or None
+      Maximal total size of nodes in a community. If zero, then communities can
+      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -536,12 +580,16 @@ class Optimiser(object):
     """
     if (consider_comms is None):
       consider_comms = self.consider_comms
+
+    if max_comm_size is None:
+        max_comm_size = self.max_comm_size
+
     diff = _c_leiden._Optimiser_merge_nodes(
-            self._optimiser, partition._partition, is_membership_fixed, consider_comms)
+            self._optimiser, partition._partition, is_membership_fixed, consider_comms, max_comm_size)
     partition._update_internal_membership()
     return diff
 
-  def merge_nodes_constrained(self, partition, constrained_partition, consider_comms=None):
+  def merge_nodes_constrained(self, partition, constrained_partition, consider_comms=None, max_comm_size=None):
     """ Merge nodes for *refining* the partition.
 
     Parameters
@@ -555,6 +603,10 @@ class Optimiser(object):
     consider_comms
       If ``None`` uses :attr:`refine_consider_comms`, but can be set
       to something else.
+
+    max_comm_size : int or None
+      Maximal total size of nodes in a community. If zero, then communities can
+      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -586,7 +638,11 @@ class Optimiser(object):
     """
     if (consider_comms is None):
       consider_comms = self.refine_consider_comms
-    diff =  _c_leiden._Optimiser_merge_nodes_constrained(self._optimiser, partition._partition, constrained_partition._partition, consider_comms)
+
+    if max_comm_size is None:
+        max_comm_size = self.max_comm_size
+
+    diff =  _c_leiden._Optimiser_merge_nodes_constrained(self._optimiser, partition._partition, constrained_partition._partition, consider_comms, max_comm_size)
     partition._update_internal_membership()
     return diff
 

--- a/src/Optimiser.py
+++ b/src/Optimiser.py
@@ -265,7 +265,7 @@ class Optimiser(object):
 
     max_comm_size : int or None
       Maximal total size of nodes in a community. If zero, then communities can
-      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
+      be of any size. If ``None`` (the default), uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -334,7 +334,7 @@ class Optimiser(object):
 
     max_comm_size : int or None
       Maximal total size of nodes in a community. If zero, then communities can
-      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
+      be of any size. If ``None`` (the default), uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -444,7 +444,7 @@ class Optimiser(object):
 
     max_comm_size : int or None
       Maximal total size of nodes in a community. If zero, then communities can
-      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
+      be of any size. If ``None`` (the default), uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -551,7 +551,7 @@ class Optimiser(object):
 
     max_comm_size : int or None
       Maximal total size of nodes in a community. If zero, then communities can
-      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
+      be of any size. If ``None`` (the default), uses :attr:`max_comm_size`.
 
     Returns
     -------
@@ -606,7 +606,7 @@ class Optimiser(object):
 
     max_comm_size : int or None
       Maximal total size of nodes in a community. If zero, then communities can
-      be of any size. If ``None`` (the default), uses uses :attr:`max_comm_size`.
+      be of any size. If ``None`` (the default), uses :attr:`max_comm_size`.
 
     Returns
     -------

--- a/src/VertexPartition.py
+++ b/src/VertexPartition.py
@@ -426,7 +426,7 @@ class ModularityVertexPartition(MutableVertexPartition):
          in Directed Networks. Physical Review Letters, 100(11), 118703.
          `10.1103/PhysRevLett.100.118703 <https://doi.org/10.1103/PhysRevLett.100.118703>`_
    """
-  def __init__(self, graph, initial_membership=None, weights=None):
+  def __init__(self, graph, initial_membership=None, weights=None, node_sizes=None):
     """
     Parameters
     ----------
@@ -439,6 +439,11 @@ class ModularityVertexPartition(MutableVertexPartition):
 
     weights : list of double, or edge attribute
       Weights of edges. Can be either an iterable or an edge attribute.
+
+    node_sizes : list of int, or vertex attribute
+      Sizes of nodes are necessary to know the size of communities in aggregate
+      graphs. Usually this is set to 1 for all nodes, but in specific cases
+      this could be changed.
     """
     if initial_membership is not None:
       initial_membership = list(initial_membership)
@@ -454,12 +459,12 @@ class ModularityVertexPartition(MutableVertexPartition):
         weights = list(weights)
 
     self._partition = _c_leiden._new_ModularityVertexPartition(pygraph_t,
-        initial_membership, weights)
+        initial_membership, weights, node_sizes)
     self._update_internal_membership()
 
   def __deepcopy__(self, memo):
     n, directed, edges, weights, node_sizes = _c_leiden._MutableVertexPartition_get_py_igraph(self._partition)
-    new_partition = ModularityVertexPartition(self.graph, self.membership, weights)
+    new_partition = ModularityVertexPartition(self.graph, self.membership, weights, node_sizes)
     return new_partition
 
 class SurpriseVertexPartition(MutableVertexPartition):
@@ -532,8 +537,15 @@ class SurpriseVertexPartition(MutableVertexPartition):
         # Make sure it is a list
         weights = list(weights)
 
+    if node_sizes is not None:
+      if isinstance(node_sizes, str):
+        node_sizes = graph.vs[node_sizes]
+      else:
+        # Make sure it is a list
+        node_sizes = list(node_sizes)
+
     self._partition = _c_leiden._new_SurpriseVertexPartition(pygraph_t,
-        initial_membership, weights)
+        initial_membership, weights, node_sizes)
     self._update_internal_membership()
 
   def __deepcopy__(self, memo):
@@ -598,7 +610,14 @@ class SignificanceVertexPartition(MutableVertexPartition):
 
     pygraph_t = _get_py_capsule(graph)
 
-    self._partition = _c_leiden._new_SignificanceVertexPartition(pygraph_t, initial_membership)
+    if node_sizes is not None:
+      if isinstance(node_sizes, str):
+        node_sizes = graph.vs[node_sizes]
+      else:
+        # Make sure it is a list
+        node_sizes = list(node_sizes)
+
+    self._partition = _c_leiden._new_SignificanceVertexPartition(pygraph_t, initial_membership, node_sizes)
     self._update_internal_membership()
 
   def __deepcopy__(self, memo):
@@ -786,7 +805,7 @@ class RBConfigurationVertexPartition(LinearResolutionParameterVertexPartition):
          `10.1103/PhysRevLett.100.118703 <https://doi.org/10.1103/PhysRevLett.100.118703>`_
 
    """
-  def __init__(self, graph, initial_membership=None, weights=None, resolution_parameter=1.0):
+  def __init__(self, graph, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1.0):
     """
     Parameters
     ----------
@@ -799,6 +818,11 @@ class RBConfigurationVertexPartition(LinearResolutionParameterVertexPartition):
 
     weights : list of double, or edge attribute
       Weights of edges. Can be either an iterable or an edge attribute.
+
+    node_sizes : list of int, or vertex attribute
+      Sizes of nodes are necessary to know the size of communities in aggregate
+      graphs. Usually this is set to 1 for all nodes, but in specific cases
+      this could be changed.
 
     resolution_parameter : double
       Resolution parameter.
@@ -817,13 +841,20 @@ class RBConfigurationVertexPartition(LinearResolutionParameterVertexPartition):
         # Make sure it is a list
         weights = list(weights)
 
+    if node_sizes is not None:
+      if isinstance(node_sizes, str):
+        node_sizes = graph.vs[node_sizes]
+      else:
+        # Make sure it is a list
+        node_sizes = list(node_sizes)
+
     self._partition = _c_leiden._new_RBConfigurationVertexPartition(pygraph_t,
-        initial_membership, weights, resolution_parameter)
+        initial_membership, weights, node_sizes, resolution_parameter)
     self._update_internal_membership()
 
   def __deepcopy__(self, memo):
     n, directed, edges, weights, node_sizes = _c_leiden._MutableVertexPartition_get_py_igraph(self._partition)
-    new_partition = RBConfigurationVertexPartition(self.graph, self.membership, weights, self.resolution_parameter)
+    new_partition = RBConfigurationVertexPartition(self.graph, self.membership, weights, node_sizes, self.resolution_parameter)
     return new_partition
 
 class CPMVertexPartition(LinearResolutionParameterVertexPartition):

--- a/src/functions.py
+++ b/src/functions.py
@@ -23,7 +23,7 @@ def _get_py_capsule(graph):
 from .VertexPartition import *
 from .Optimiser import *
 
-def find_partition(graph, partition_type, initial_membership=None, weights=None, n_iterations=2, seed=None, max_comm_size=0, **kwargs):
+def find_partition(graph, partition_type, initial_membership=None, weights=None, n_iterations=2, seed=None, **kwargs):
   """ Detect communities using the default settings.
 
   This function detects communities given the specified method in the
@@ -53,10 +53,6 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
-
-  max_comm_size : int
-    Maximal total size of nodes in a community. If zero (the default), then
-    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -91,11 +87,11 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
-  optimiser.optimise_partition(partition, n_iterations=n_iterations, max_comm_size=max_comm_size)
+  optimiser.optimise_partition(partition, n_iterations)
 
   return partition
 
-def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, max_comm_size=0, **kwargs):
+def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, **kwargs):
   """ Detect communities for multiplex graphs.
 
   Each graph should be defined on the same set of vertices, only the edges may
@@ -115,10 +111,6 @@ def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, 
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
-
-  max_comm_size : int
-    Maximal total size of nodes in a community. If zero (the default), then
-    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -166,7 +158,7 @@ def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, 
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
-  improvement = optimiser.optimise_partition_multiplex(partitions, layer_weights, n_iterations, max_comm_size=max_comm_size)
+  improvement = optimiser.optimise_partition_multiplex(partitions, layer_weights, n_iterations)
 
   return partitions[0].membership, improvement
 
@@ -174,7 +166,7 @@ def find_partition_temporal(graphs, partition_type,
                             interslice_weight=1,
                             slice_attr='slice', vertex_id_attr='id',
                             edge_type_attr='type', weight_attr='weight',
-                            n_iterations=2, seed=None, max_comm_size=0,
+                            n_iterations=2, seed=None,
                             **kwargs):
   """ Detect communities for temporal graphs.
 
@@ -217,10 +209,6 @@ def find_partition_temporal(graphs, partition_type,
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
-
-  max_comm_size : int
-    Maximal total size of nodes in a community. If zero (the default), then
-    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -287,7 +275,7 @@ def find_partition_temporal(graphs, partition_type,
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
-  improvement = optimiser.optimise_partition_multiplex(partitions + [partition_interslice], n_iterations=n_iterations, max_comm_size=max_comm_size)
+  improvement = optimiser.optimise_partition_multiplex(partitions + [partition_interslice], n_iterations=n_iterations)
 
   # Transform results back into original form.
   membership = {(v[slice_attr], v[vertex_id_attr]): m for v, m in zip(G.vs, partitions[0].membership)}

--- a/src/functions.py
+++ b/src/functions.py
@@ -88,8 +88,6 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
                              **kwargs)
   optimiser = Optimiser()
 
-  if max_comm_size < 0:
-    raise ValueError('negative max_comm_size: %s' % max_comm_size)
   optimiser.max_comm_size = max_comm_size
 
   if (not seed is None):
@@ -163,8 +161,6 @@ def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, 
     partitions.append(partition_type(graph, **kwargs))
   optimiser = Optimiser()
 
-  if max_comm_size < 0:
-    raise ValueError('negative max_comm_size: %s' % max_comm_size)
   optimiser.max_comm_size = max_comm_size;
 
   if (not seed is None):
@@ -288,8 +284,6 @@ def find_partition_temporal(graphs, partition_type,
                                             node_sizes='node_size', weights=weight_attr)
   optimiser = Optimiser()
 
-  if max_comm_size < 0:
-    raise ValueError('negative max_comm_size: %s' % max_comm_size)
   optimiser.max_comm_size = max_comm_size
 
   if (not seed is None):

--- a/src/functions.py
+++ b/src/functions.py
@@ -23,7 +23,7 @@ def _get_py_capsule(graph):
 from .VertexPartition import *
 from .Optimiser import *
 
-def find_partition(graph, partition_type, initial_membership=None, weights=None, n_iterations=2, seed=None, **kwargs):
+def find_partition(graph, partition_type, initial_membership=None, weights=None, n_iterations=2, max_comm_size=0, seed=None, **kwargs):
   """ Detect communities using the default settings.
 
   This function detects communities given the specified method in the
@@ -54,6 +54,10 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
 
+  max_comm_size : non-negative int
+    Maximal total size of nodes in a community. If zero (the default), then
+    communities can be of any size.
+
   seed : int
     Seed for the random number generator. By default uses a random seed
     if nothing is specified.
@@ -83,6 +87,10 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
                              initial_membership=initial_membership,
                              **kwargs)
   optimiser = Optimiser()
+
+  if max_comm_size < 0:
+    raise ValueError('negative max_comm_size: %s' % max_comm_size)
+  optimiser.max_comm_size = max_comm_size
 
   if (not seed is None):
     optimiser.set_rng_seed(seed)
@@ -155,6 +163,10 @@ def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, 
     partitions.append(partition_type(graph, **kwargs))
   optimiser = Optimiser()
 
+  if max_comm_size < 0:
+    raise ValueError('negative max_comm_size: %s' % max_comm_size)
+  optimiser.max_comm_size = max_comm_size;
+
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
@@ -166,7 +178,7 @@ def find_partition_temporal(graphs, partition_type,
                             interslice_weight=1,
                             slice_attr='slice', vertex_id_attr='id',
                             edge_type_attr='type', weight_attr='weight',
-                            n_iterations=2, seed=None,
+                            n_iterations=2, max_comm_size=0, seed=None,
                             **kwargs):
   """ Detect communities for temporal graphs.
 
@@ -209,6 +221,10 @@ def find_partition_temporal(graphs, partition_type,
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
+
+  max_comm_size : non-negative int
+    Maximal total size of nodes in a community. If zero (the default), then
+    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -271,6 +287,10 @@ def find_partition_temporal(graphs, partition_type,
   partition_interslice = CPMVertexPartition(G_interslice, resolution_parameter=0,
                                             node_sizes='node_size', weights=weight_attr)
   optimiser = Optimiser()
+
+  if max_comm_size < 0:
+    raise ValueError('negative max_comm_size: %s' % max_comm_size)
+  optimiser.max_comm_size = max_comm_size
 
   if (not seed is None):
     optimiser.set_rng_seed(seed)

--- a/src/functions.py
+++ b/src/functions.py
@@ -23,7 +23,7 @@ def _get_py_capsule(graph):
 from .VertexPartition import *
 from .Optimiser import *
 
-def find_partition(graph, partition_type, initial_membership=None, weights=None, n_iterations=2, seed=None, **kwargs):
+def find_partition(graph, partition_type, initial_membership=None, weights=None, n_iterations=2, seed=None, max_comm_size=0, **kwargs):
   """ Detect communities using the default settings.
 
   This function detects communities given the specified method in the
@@ -53,6 +53,10 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
+
+  max_comm_size : int
+    Maximal total size of nodes in a community. If zero (the default), then
+    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -87,11 +91,11 @@ def find_partition(graph, partition_type, initial_membership=None, weights=None,
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
-  optimiser.optimise_partition(partition, n_iterations)
+  optimiser.optimise_partition(partition, n_iterations=n_iterations, max_comm_size=max_comm_size)
 
   return partition
 
-def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, **kwargs):
+def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, max_comm_size=0, **kwargs):
   """ Detect communities for multiplex graphs.
 
   Each graph should be defined on the same set of vertices, only the edges may
@@ -111,6 +115,10 @@ def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, 
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
+
+  max_comm_size : int
+    Maximal total size of nodes in a community. If zero (the default), then
+    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -158,7 +166,7 @@ def find_partition_multiplex(graphs, partition_type, n_iterations=2, seed=None, 
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
-  improvement = optimiser.optimise_partition_multiplex(partitions, layer_weights, n_iterations)
+  improvement = optimiser.optimise_partition_multiplex(partitions, layer_weights, n_iterations, max_comm_size=max_comm_size)
 
   return partitions[0].membership, improvement
 
@@ -166,7 +174,7 @@ def find_partition_temporal(graphs, partition_type,
                             interslice_weight=1,
                             slice_attr='slice', vertex_id_attr='id',
                             edge_type_attr='type', weight_attr='weight',
-                            n_iterations=2, seed=None,
+                            n_iterations=2, seed=None, max_comm_size=0,
                             **kwargs):
   """ Detect communities for temporal graphs.
 
@@ -209,6 +217,10 @@ def find_partition_temporal(graphs, partition_type,
     Number of iterations to run the Leiden algorithm. By default, 2 iterations
     are run. If the number of iterations is negative, the Leiden algorithm is
     run until an iteration in which there was no improvement.
+
+  max_comm_size : int
+    Maximal total size of nodes in a community. If zero (the default), then
+    communities can be of any size.
 
   seed : int
     Seed for the random number generator. By default uses a random seed
@@ -275,7 +287,7 @@ def find_partition_temporal(graphs, partition_type,
   if (not seed is None):
     optimiser.set_rng_seed(seed)
 
-  improvement = optimiser.optimise_partition_multiplex(partitions + [partition_interslice], n_iterations=n_iterations)
+  improvement = optimiser.optimise_partition_multiplex(partitions + [partition_interslice], n_iterations=n_iterations, max_comm_size=max_comm_size)
 
   # Transform results back into original form.
   membership = {(v[slice_attr], v[vertex_id_attr]): m for v, m in zip(G.vs, partitions[0].membership)}

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -928,11 +928,7 @@ extern "C"
       cerr << "Using optimiser at address " << optimiser << endl;
     #endif
 
-    #ifdef IS_PY3K
-    return PyLong_FromLong(optimiser->max_comm_size);
-    #else
-    return PyInt_FromLong(optimiser->max_comm_size);
-    #endif
+    return PyLong_FromSize_t(optimiser->max_comm_size);
   }
 
   PyObject* _Optimiser_set_rng_seed(PyObject *self, PyObject *args, PyObject *keywds)

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -40,16 +40,18 @@ extern "C"
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
     PyObject* py_is_membership_fixed = NULL;
+    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|OI", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_is_membership_fixed))
+                                     &py_is_membership_fixed,
+                                     &py_max_comm_size))
         return NULL;
 
     #ifdef DEBUG
@@ -93,10 +95,12 @@ extern "C"
       }
     }
 
+    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
+
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partition, is_membership_fixed);
+      q = optimiser->optimise_partition(partition, is_membership_fixed, max_comm_size);
     }
     catch (std::exception e)
     {
@@ -112,16 +116,17 @@ extern "C"
     PyObject* py_partitions = NULL;
     PyObject* py_layer_weights = NULL;
     PyObject* py_is_membership_fixed = NULL;
+    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partitions", "layer_weights", "is_membership_fixed", NULL};
+    static char* kwlist[] = {"optimiser", "partitions", "layer_weights", "is_membership_fixed", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|O", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|OI", kwlist,
                                      &py_optimiser, &py_partitions,
-                                     &py_layer_weights, &py_is_membership_fixed))
+                                     &py_layer_weights, &py_is_membership_fixed, &py_max_comm_size))
         return NULL;
 
     size_t nb_partitions = PyList_Size(py_partitions);
@@ -194,7 +199,6 @@ extern "C"
       }
     }
 
-
     #ifdef DEBUG
       cerr << "Capsule optimiser at address " << py_optimiser << endl;
     #endif
@@ -203,10 +207,12 @@ extern "C"
       cerr << "Using optimiser at address " << optimiser << endl;
     #endif
 
+    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
+
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partitions, layer_weights, is_membership_fixed);
+      q = optimiser->optimise_partition(partitions, layer_weights, is_membership_fixed, max_comm_size);
     }
     catch (std::exception e)
     {
@@ -222,16 +228,17 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_is_membership_fixed = NULL;
     int consider_comms = -1;
+    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|OiI", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_is_membership_fixed, &consider_comms))
+                                     &py_is_membership_fixed, &consider_comms, &py_max_comm_size))
         return NULL;
 
     #ifdef DEBUG
@@ -278,10 +285,12 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->consider_comms;
 
+    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
+
     double q  = 0.0;
     try
     {
-      q = optimiser->move_nodes(partition, is_membership_fixed, consider_comms, true);
+      q = optimiser->move_nodes(partition, is_membership_fixed, consider_comms, true, max_comm_size);
     }
     catch (std::exception e)
     {
@@ -297,16 +306,17 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_is_membership_fixed = NULL;
     int consider_comms = -1;
+    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|OiI", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_is_membership_fixed, &consider_comms))
+                                     &py_is_membership_fixed, &consider_comms, &py_max_comm_size))
         return NULL;
 
     #ifdef DEBUG
@@ -353,10 +363,12 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->consider_comms;
 
+    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
+
     double q = 0.0;
     try
     {
-      q = optimiser->merge_nodes(partition, is_membership_fixed, consider_comms, true);
+      q = optimiser->merge_nodes(partition, is_membership_fixed, consider_comms, true, max_comm_size);
     }
     catch (std::exception e)
     {
@@ -372,15 +384,16 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_constrained_partition = NULL;
     int consider_comms = -1;
+    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|i", kwlist,
-                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|iI", kwlist,
+                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms, &py_max_comm_size))
         return NULL;
 
     #ifdef DEBUG
@@ -414,10 +427,12 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->refine_consider_comms;
 
+    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
+
     double q = 0.0;
     try
     {
-      q = optimiser->move_nodes_constrained(partition, consider_comms, constrained_partition);
+      q = optimiser->move_nodes_constrained(partition, consider_comms, constrained_partition, max_comm_size);
     }
     catch (std::exception e)
     {
@@ -433,15 +448,16 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_constrained_partition = NULL;
     int consider_comms = -1;
+    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|i", kwlist,
-                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|iI", kwlist,
+                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms, &py_max_comm_size))
         return NULL;
 
     #ifdef DEBUG
@@ -475,10 +491,12 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->refine_consider_comms;
 
+    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
+
     double q = 0.0;
     try
     {
-      q = optimiser->merge_nodes_constrained(partition, consider_comms, constrained_partition);
+      q = optimiser->merge_nodes_constrained(partition, consider_comms, constrained_partition, max_comm_size);
     }
     catch (std::exception e)
     {
@@ -869,6 +887,70 @@ extern "C"
     #endif
 
     return PyBool_FromLong(optimiser->refine_partition);
+  }
+
+  PyObject* _Optimiser_set_max_comm_size(PyObject *self, PyObject *args, PyObject *keywds)
+  {
+    PyObject* py_optimiser = NULL;
+    size_t max_comm_size = 0;
+    static char* kwlist[] = {"optimiser", "max_comm_size", NULL};
+
+    #ifdef DEBUG
+      cerr << "Parsing arguments..." << endl;
+    #endif
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OI", kwlist,
+                                     &py_optimiser, &max_comm_size))
+        return NULL;
+
+    #ifdef DEBUG
+      cerr << "set_max_comm_size(" << max_comm_size << ");" << endl;
+    #endif
+
+    #ifdef DEBUG
+      cerr << "Capsule optimiser at address " << py_optimiser << endl;
+    #endif
+    Optimiser* optimiser = decapsule_Optimiser(py_optimiser);
+    #ifdef DEBUG
+      cerr << "Using optimiser at address " << optimiser << endl;
+    #endif
+
+    optimiser->max_comm_size = max_comm_size;
+
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  PyObject* _Optimiser_get_max_comm_size(PyObject *self, PyObject *args, PyObject *keywds)
+  {
+    PyObject* py_optimiser = NULL;
+    static char* kwlist[] = {"optimiser", NULL};
+
+    #ifdef DEBUG
+      cerr << "Parsing arguments..." << endl;
+    #endif
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O", kwlist,
+                                     &py_optimiser))
+        return NULL;
+
+    #ifdef DEBUG
+      cerr << "get_max_comm_size();" << endl;
+    #endif
+
+    #ifdef DEBUG
+      cerr << "Capsule optimiser at address " << py_optimiser << endl;
+    #endif
+    Optimiser* optimiser = decapsule_Optimiser(py_optimiser);
+    #ifdef DEBUG
+      cerr << "Using optimiser at address " << optimiser << endl;
+    #endif
+
+    #ifdef IS_PY3K
+    return PyLong_FromLong(optimiser->max_comm_size);
+    #else
+    return PyInt_FromLong(optimiser->max_comm_size);
+    #endif
   }
 
   PyObject* _Optimiser_set_rng_seed(PyObject *self, PyObject *args, PyObject *keywds)

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -874,14 +874,14 @@ extern "C"
   PyObject* _Optimiser_set_max_comm_size(PyObject *self, PyObject *args, PyObject *keywds)
   {
     PyObject* py_optimiser = NULL;
-    unsigned int max_comm_size = 0;
+    size_t max_comm_size = 0;
     static char* kwlist[] = {"optimiser", "max_comm_size", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "On", kwlist,
                                      &py_optimiser, &max_comm_size))
         return NULL;
 

--- a/src/python_optimiser_interface.cpp
+++ b/src/python_optimiser_interface.cpp
@@ -40,18 +40,16 @@ extern "C"
     PyObject* py_optimiser = NULL;
     PyObject* py_partition = NULL;
     PyObject* py_is_membership_fixed = NULL;
-    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "max_comm_size", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|OI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|O", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_is_membership_fixed,
-                                     &py_max_comm_size))
+                                     &py_is_membership_fixed))
         return NULL;
 
     #ifdef DEBUG
@@ -95,12 +93,10 @@ extern "C"
       }
     }
 
-    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
-
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partition, is_membership_fixed, max_comm_size);
+      q = optimiser->optimise_partition(partition, is_membership_fixed);
     }
     catch (std::exception e)
     {
@@ -116,17 +112,16 @@ extern "C"
     PyObject* py_partitions = NULL;
     PyObject* py_layer_weights = NULL;
     PyObject* py_is_membership_fixed = NULL;
-    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partitions", "layer_weights", "is_membership_fixed", "max_comm_size", NULL};
+    static char* kwlist[] = {"optimiser", "partitions", "layer_weights", "is_membership_fixed", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|OI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|O", kwlist,
                                      &py_optimiser, &py_partitions,
-                                     &py_layer_weights, &py_is_membership_fixed, &py_max_comm_size))
+                                     &py_layer_weights, &py_is_membership_fixed))
         return NULL;
 
     size_t nb_partitions = PyList_Size(py_partitions);
@@ -199,6 +194,7 @@ extern "C"
       }
     }
 
+
     #ifdef DEBUG
       cerr << "Capsule optimiser at address " << py_optimiser << endl;
     #endif
@@ -207,12 +203,10 @@ extern "C"
       cerr << "Using optimiser at address " << optimiser << endl;
     #endif
 
-    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
-
     double q = 0.0;
     try
     {
-      q = optimiser->optimise_partition(partitions, layer_weights, is_membership_fixed, max_comm_size);
+      q = optimiser->optimise_partition(partitions, layer_weights, is_membership_fixed);
     }
     catch (std::exception e)
     {
@@ -228,17 +222,16 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_is_membership_fixed = NULL;
     int consider_comms = -1;
-    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", "max_comm_size", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|OiI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_is_membership_fixed, &consider_comms, &py_max_comm_size))
+                                     &py_is_membership_fixed, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -285,12 +278,10 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->consider_comms;
 
-    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
-
     double q  = 0.0;
     try
     {
-      q = optimiser->move_nodes(partition, is_membership_fixed, consider_comms, true, max_comm_size);
+      q = optimiser->move_nodes(partition, is_membership_fixed, consider_comms, true);
     }
     catch (std::exception e)
     {
@@ -306,17 +297,16 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_is_membership_fixed = NULL;
     int consider_comms = -1;
-    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", "max_comm_size", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "is_membership_fixed", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|OiI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Oi", kwlist,
                                      &py_optimiser, &py_partition,
-                                     &py_is_membership_fixed, &consider_comms, &py_max_comm_size))
+                                     &py_is_membership_fixed, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -363,12 +353,10 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->consider_comms;
 
-    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
-
     double q = 0.0;
     try
     {
-      q = optimiser->merge_nodes(partition, is_membership_fixed, consider_comms, true, max_comm_size);
+      q = optimiser->merge_nodes(partition, is_membership_fixed, consider_comms, true);
     }
     catch (std::exception e)
     {
@@ -384,16 +372,15 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_constrained_partition = NULL;
     int consider_comms = -1;
-    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", "max_comm_size", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|iI", kwlist,
-                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms, &py_max_comm_size))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|i", kwlist,
+                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -427,12 +414,10 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->refine_consider_comms;
 
-    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
-
     double q = 0.0;
     try
     {
-      q = optimiser->move_nodes_constrained(partition, consider_comms, constrained_partition, max_comm_size);
+      q = optimiser->move_nodes_constrained(partition, consider_comms, constrained_partition);
     }
     catch (std::exception e)
     {
@@ -448,16 +433,15 @@ extern "C"
     PyObject* py_partition = NULL;
     PyObject* py_constrained_partition = NULL;
     int consider_comms = -1;
-    int py_max_comm_size = -1;
 
-    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", "max_comm_size", NULL};
+    static char* kwlist[] = {"optimiser", "partition", "constrained_partition", "consider_comms", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|iI", kwlist,
-                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms, &py_max_comm_size))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "OOO|i", kwlist,
+                                     &py_optimiser, &py_partition, &py_constrained_partition, &consider_comms))
         return NULL;
 
     #ifdef DEBUG
@@ -491,12 +475,10 @@ extern "C"
     if (consider_comms < 0)
       consider_comms = optimiser->refine_consider_comms;
 
-    size_t max_comm_size = py_max_comm_size >= 0 ? py_max_comm_size : optimiser->max_comm_size;
-
     double q = 0.0;
     try
     {
-      q = optimiser->merge_nodes_constrained(partition, consider_comms, constrained_partition, max_comm_size);
+      q = optimiser->merge_nodes_constrained(partition, consider_comms, constrained_partition);
     }
     catch (std::exception e)
     {
@@ -892,7 +874,7 @@ extern "C"
   PyObject* _Optimiser_set_max_comm_size(PyObject *self, PyObject *args, PyObject *keywds)
   {
     PyObject* py_optimiser = NULL;
-    size_t max_comm_size = 0;
+    unsigned int max_comm_size = 0;
     static char* kwlist[] = {"optimiser", "max_comm_size", NULL};
 
     #ifdef DEBUG

--- a/src/python_partition_interface.cpp
+++ b/src/python_partition_interface.cpp
@@ -9,22 +9,17 @@ Graph* create_graph_from_py(PyObject* py_obj_graph)
   return create_graph_from_py(py_obj_graph, NULL, NULL, false);
 }
 
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights)
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes)
 {
-  return create_graph_from_py(py_obj_graph, py_weights, NULL, true);
+  return create_graph_from_py(py_obj_graph, py_node_sizes, NULL, true);
 }
 
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights, int check_positive_weight)
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights)
 {
-  return create_graph_from_py(py_obj_graph, py_weights, NULL, check_positive_weight);
+  return create_graph_from_py(py_obj_graph, py_node_sizes, py_weights, true);
 }
 
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights, PyObject* py_node_sizes)
-{
-  return create_graph_from_py(py_obj_graph, py_weights, py_node_sizes, true);
-}
-
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_weights, PyObject* py_node_sizes, int check_positive_weight)
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, int check_positive_weight)
 {
   #ifdef DEBUG
     cerr << "create_graph_from_py" << endl;
@@ -172,17 +167,18 @@ extern "C"
     PyObject* py_obj_graph = NULL;
     PyObject* py_initial_membership = NULL;
     PyObject* py_weights = NULL;
+    PyObject* py_node_sizes = NULL;
 
-    static char* kwlist[] = {"graph", "initial_membership", "weights", NULL};
+    static char* kwlist[] = {"graph", "initial_membership", "weights", "node_sizes", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OO", kwlist,
-                                     &py_obj_graph, &py_initial_membership, &py_weights))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OOO", kwlist,
+                                     &py_obj_graph, &py_initial_membership, &py_weights, &py_node_sizes))
         return NULL;
 
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph, py_weights);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights);
 
       ModularityVertexPartition* partition = NULL;
 
@@ -251,17 +247,18 @@ extern "C"
   {
     PyObject* py_obj_graph = NULL;
     PyObject* py_initial_membership = NULL;
+    PyObject* py_node_sizes = NULL;
 
-    static char* kwlist[] = {"graph", "initial_membership", NULL};
+    static char* kwlist[] = {"graph", "initial_membership", "node_sizes", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|O", kwlist,
-                                     &py_obj_graph, &py_initial_membership))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OO", kwlist,
+                                     &py_obj_graph, &py_initial_membership, &py_node_sizes))
         return NULL;
 
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes);
 
       SignificanceVertexPartition* partition = NULL;
 
@@ -330,17 +327,18 @@ extern "C"
     PyObject* py_obj_graph = NULL;
     PyObject* py_initial_membership = NULL;
     PyObject* py_weights = NULL;
+    PyObject* py_node_sizes = NULL;
 
-    static char* kwlist[] = {"graph", "initial_membership", "weights", NULL};
+    static char* kwlist[] = {"graph", "initial_membership", "weights", "node_sizes", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OO", kwlist,
-                                     &py_obj_graph, &py_initial_membership, &py_weights))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OOO", kwlist,
+                                     &py_obj_graph, &py_initial_membership, &py_weights, &py_node_sizes))
         return NULL;
 
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph, py_weights);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights);
 
       SurpriseVertexPartition* partition = NULL;
 
@@ -421,7 +419,7 @@ extern "C"
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph, py_weights, py_node_sizes, false);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights, false);
 
       CPMVertexPartition* partition = NULL;
 
@@ -505,7 +503,7 @@ extern "C"
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph, py_weights, py_node_sizes);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights);
 
       RBERVertexPartition* partition = NULL;
 
@@ -574,18 +572,19 @@ extern "C"
     PyObject* py_obj_graph = NULL;
     PyObject* py_initial_membership = NULL;
     PyObject* py_weights = NULL;
+    PyObject* py_node_sizes = NULL;
     double resolution_parameter = 1.0;
 
-    static char* kwlist[] = {"graph", "initial_membership", "weights", "resolution_parameter", NULL};
+    static char* kwlist[] = {"graph", "initial_membership", "weights", "node_sizes", "resolution_parameter", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OOd", kwlist,
-                                     &py_obj_graph, &py_initial_membership, &py_weights, &resolution_parameter))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OOOd", kwlist,
+                                     &py_obj_graph, &py_initial_membership, &py_weights, &py_node_sizes, &resolution_parameter))
         return NULL;
 
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph, py_weights);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights);
 
       RBConfigurationVertexPartition* partition = NULL;
 

--- a/src/python_partition_interface.cpp
+++ b/src/python_partition_interface.cpp
@@ -4,11 +4,6 @@
 #define IS_PY3K
 #endif
 
-Graph* create_graph_from_py(PyObject* py_obj_graph)
-{
-  return create_graph_from_py(py_obj_graph, NULL, NULL, false);
-}
-
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes)
 {
   return create_graph_from_py(py_obj_graph, py_node_sizes, NULL, true);

--- a/tests/test_Optimiser.py
+++ b/tests/test_Optimiser.py
@@ -94,6 +94,19 @@ class OptimiserTest(unittest.TestCase):
         partition.sizes(), 10*[10],
         msg="After optimising partition (max_comm_size=10) failed to find different components with CPMVertexPartition(resolution_parameter=0)");
 
+  def test_optimiser_split_with_max_comm_size(self):
+    G = ig.Graph.Full(100);
+    partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.5);
+    self.optimiser.merge_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS);
+    self.assertListEqual(
+        partition.sizes(), [100],
+        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after merge nodes incorrect.");
+    self.optimiser.max_comm_size = 10
+    self.optimiser.optimise_partition(partition);
+    self.assertListEqual(
+        partition.sizes(), 10*[10],
+        msg="After optimising partition (max_comm_size=10) failed to find different components with CPMVertexPartition(resolution_parameter=0.5)");
+
   def test_optimiser_with_is_membership_fixed(self):
       G = ig.Graph.Full(3)
       partition = leidenalg.CPMVertexPartition(

--- a/tests/test_Optimiser.py
+++ b/tests/test_Optimiser.py
@@ -24,10 +24,11 @@ class OptimiserTest(unittest.TestCase):
   def test_move_nodes_with_max_comm_size(self):
     G = ig.Graph.Full(100);
     partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.5);
-    self.optimiser.move_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS, max_comm_size=17);
+    self.optimiser.max_comm_size = 17
+    self.optimiser.move_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS);
     self.assertListEqual(
         partition.sizes(), [17, 17, 17, 17, 17, 15],
-        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after move nodes incorrect.");
+        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after move nodes (max_comm_size=17) incorrect.");
 
   def test_move_nodes_with_fixed(self):
     # One edge plus singleton, but the two connected nodes are fixed
@@ -56,10 +57,11 @@ class OptimiserTest(unittest.TestCase):
   def test_merge_nodes_with_max_comm_size(self):
     G = ig.Graph.Full(100);
     partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.5);
-    self.optimiser.merge_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS, max_comm_size=17);
+    self.optimiser.max_comm_size = 17
+    self.optimiser.merge_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS);
     self.assertListEqual(
         partition.sizes(), [17, 17, 17, 17, 17, 15],
-        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after merge nodes incorrect.");
+        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after merge nodes (max_comm_size=17) incorrect.");
 
   def test_diff_move_node_optimality(self):
     G = ig.Graph.Erdos_Renyi(100, p=5./100, directed=False, loops=False);
@@ -86,10 +88,11 @@ class OptimiserTest(unittest.TestCase):
     G = ig.Graph.Full(100);
     partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0);
     self.optimiser.consider_comms=leidenalg.ALL_NEIGH_COMMS;
-    self.optimiser.optimise_partition(partition, max_comm_size=10);
+    self.optimiser.max_comm_size = 10
+    self.optimiser.optimise_partition(partition);
     self.assertListEqual(
         partition.sizes(), 10*[10],
-        msg="After optimising partition failed to find different components with CPMVertexPartition(resolution_parameter=0)");
+        msg="After optimising partition (max_comm_size=10) failed to find different components with CPMVertexPartition(resolution_parameter=0)");
 
   def test_optimiser_with_is_membership_fixed(self):
       G = ig.Graph.Full(3)

--- a/tests/test_Optimiser.py
+++ b/tests/test_Optimiser.py
@@ -21,6 +21,14 @@ class OptimiserTest(unittest.TestCase):
         partition.sizes(), [100],
         msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after move nodes incorrect.");
 
+  def test_move_nodes_with_max_comm_size(self):
+    G = ig.Graph.Full(100);
+    partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.5);
+    self.optimiser.move_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS, max_comm_size=17);
+    self.assertListEqual(
+        partition.sizes(), [17, 17, 17, 17, 17, 15],
+        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after move nodes incorrect.");
+
   def test_move_nodes_with_fixed(self):
     # One edge plus singleton, but the two connected nodes are fixed
     G = ig.Graph([(0, 2)])
@@ -45,6 +53,14 @@ class OptimiserTest(unittest.TestCase):
         G.ecount(),
         msg="total_weight_in_all_comms not equal to ecount of graph.");
 
+  def test_merge_nodes_with_max_comm_size(self):
+    G = ig.Graph.Full(100);
+    partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.5);
+    self.optimiser.merge_nodes(partition, consider_comms=leidenalg.ALL_NEIGH_COMMS, max_comm_size=17);
+    self.assertListEqual(
+        partition.sizes(), [17, 17, 17, 17, 17, 15],
+        msg="CPMVertexPartition(resolution_parameter=0.5) of complete graph after merge nodes incorrect.");
+
   def test_diff_move_node_optimality(self):
     G = ig.Graph.Erdos_Renyi(100, p=5./100, directed=False, loops=False);
     partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0.1);
@@ -62,6 +78,15 @@ class OptimiserTest(unittest.TestCase):
     partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0);
     self.optimiser.consider_comms=leidenalg.ALL_NEIGH_COMMS;
     self.optimiser.optimise_partition(partition);
+    self.assertListEqual(
+        partition.sizes(), 10*[10],
+        msg="After optimising partition failed to find different components with CPMVertexPartition(resolution_parameter=0)");
+
+  def test_optimiser_with_max_comm_size(self):
+    G = ig.Graph.Full(100);
+    partition = leidenalg.CPMVertexPartition(G, resolution_parameter=0);
+    self.optimiser.consider_comms=leidenalg.ALL_NEIGH_COMMS;
+    self.optimiser.optimise_partition(partition, max_comm_size=10);
     self.assertListEqual(
         partition.sizes(), 10*[10],
         msg="After optimising partition failed to find different components with CPMVertexPartition(resolution_parameter=0)");


### PR DESCRIPTION
First, thanks for publishing this package, and for supporting the "Surprise" goal function. I was working along these lines and just having it all be ready-made (and published) helped a lot.

I'm re-implementing the Metacell algorithm for analyzing single-cell RNA sequence data, and scaling it up to efficiently deal with very large data (many millions of cells) by converting it to a divide-and-conquer algorithm. I'm working on this as my PhD project in the Weizmann Institure for Science in Amos Tanay's lab.

This pull request implements a minor but important (for us) tweak to the basic clustering algorithm - restricting the maximal community size (sum of node sizes). Since metacells aren't "classical" clusters (in particular, they are defined as "the minimal sized community" that satisfies some conditions), this tweak makes it efficient to generate candidate metacells based on some KNN-graph, as part of the complete (complex) pipeline. I found that using this modified version saved CPU time and gave good results.

I tried to make this as seamless as possible with the existing code; two points where I had to tweak things were ensuring all vertex partitions allowed specifying node sizes, even if they did not directly use them, to allow passing them on to the algorithm itself; and change the parameters order for create_graph_from_py (since node_sizes became mandatory).