### PR TITLE
Correctly consider neighbouring nodes in queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CIBW_TEST_REQUIRES: ddt
-  CIBW_TEST_COMMAND: "cd {project} && python -m unittest"
+  CIBW_TEST_COMMAND: "cd {project} && python -m unittest -v"
   CIBW_SKIP: "cp27-* pp27-* cp35-*"
 
 jobs:
@@ -120,7 +120,7 @@ jobs:
           CIBW_BEFORE_BUILD: "python setup.py build_c_core"
           CIBW_BUILD: "*-${{ matrix.wheel_arch }}"
           IGRAPH_CMAKE_EXTRA_ARGS: -DCMAKE_BUILD_TYPE=Release -A ${{ matrix.cmake_arch }}
-          CIBW_TEST_COMMAND: "cd /d {project} && python -m unittest"
+          CIBW_TEST_COMMAND: "cd /d {project} && python -m unittest -v"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -164,7 +164,7 @@ jobs:
       - name: Test
         run: |
           pip install ddt
-          python -m unittest
+          python -m unittest -v
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
 
+
 env:
   CIBW_TEST_REQUIRES: ddt
   CIBW_TEST_COMMAND: "cd {project} && python -m unittest"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Next release
+- Corrected iterating over nodes (PR #70).
+
 0.8.4
 - Update C core to 0.9.1
 - Fixed caching problem (issue #62)

--- a/src/leidenalg/MutableVertexPartition.cpp
+++ b/src/leidenalg/MutableVertexPartition.cpp
@@ -373,7 +373,7 @@ vector<size_t> MutableVertexPartition::rank_order_communities(vector<MutableVert
 
   #ifdef DEBUG
     size_t n = partitions[0]->graph->vcount();
-    for (size_t layer; layer < nb_layers; layer++)
+    for (size_t layer = 0; layer < nb_layers; layer++)
     {
       for (size_t v = 0; v < n; v++)
       {

--- a/src/leidenalg/Optimiser.cpp
+++ b/src/leidenalg/Optimiser.cpp
@@ -563,8 +563,6 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
   {
     size_t v = vertex_order.front(); vertex_order.pop_front();
 
-    Graph* graph = NULL;
-    MutableVertexPartition* partition = NULL;
     // What is the current community of the node (this should be the same for all layers)
     size_t v_comm = partitions[0]->membership(v);
 
@@ -623,17 +621,15 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
     // Check if we should move to an empty community
     if (consider_empty_community)
     {
-      graph = graphs[0];
-      partition = partitions[0];
-      if ( partition->cnodes(v_comm) > 1 )  // We should not move a node when it is already in its own empty community (this may otherwise create more empty communities than nodes)
+      if ( partitions[0]->cnodes(v_comm) > 1 )  // We should not move a node when it is already in its own empty community (this may otherwise create more empty communities than nodes)
       {
-        size_t n_comms = partition->n_communities();
-        size_t comm = partition->get_empty_community();
+        size_t n_comms = partitions[0]->n_communities();
+        size_t comm = partitions[0]->get_empty_community();
         #ifdef DEBUG
-          cerr << "Checking empty community (" << comm << ") for partition " << partition << endl;
+          cerr << "Checking empty community (" << comm << ") for partition " << partitions[0] << endl;
         #endif
         comms.push_back(comm);
-        if (partition->n_communities() > n_comms)
+        if (partitions[0]->n_communities() > n_comms)
         {
           // If the empty community has just been added, we need to make sure
           // that is has also been added to the other layers
@@ -726,15 +722,18 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
         #endif
 
         // Mark neighbours as unstable (if not in new community and not fixed)
-        for (size_t u : graph->get_neighbours(v, IGRAPH_ALL))
+        for (Graph* graph : graphs)
         {
-          // If the neighbour was stable and is not in the new community, we
-          // should mark it as unstable, and add it to the queue, skipping
-          // fixed nodes
-          if (is_node_stable[u] && partition->membership(v) != max_comm && !is_membership_fixed[u])
+          for (size_t u : graph->get_neighbours(v, IGRAPH_ALL))
           {
-            vertex_order.push_back(u);
-            is_node_stable[u] = false;
+            // If the neighbour was stable and is not in the new community, we
+            // should mark it as unstable, and add it to the queue, skipping
+            // fixed nodes
+            if (is_node_stable[u] && partitions[0]->membership(u) != max_comm && !is_membership_fixed[u])
+            {
+              vertex_order.push_back(u);
+              is_node_stable[u] = false;
+            }
           }
         }
         // Keep track of number of moves
@@ -1050,8 +1049,6 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
       comm_added[comm] = false;
     comms.clear();
 
-    Graph* graph = NULL;
-    MutableVertexPartition* partition = NULL;
     // What is the current community of the node (this should be the same for all layers)
     size_t v_comm = partitions[0]->membership(v);
 
@@ -1192,15 +1189,19 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
         }
       #endif
 
-      // Mark neighbours as unstable (if not in new community)
-      for (size_t u : graph->get_neighbours(v, IGRAPH_ALL))
+      // Mark neighbours as unstable (if not in new community and not fixed)
+      for (Graph* graph : graphs)
       {
-        // If the neighbour was stable and is not in the new community, we
-        // should mark it as unstable, and add it to the queue
-        if (is_node_stable[u] && partition->membership(v) != max_comm)
+        for (size_t u : graph->get_neighbours(v, IGRAPH_ALL))
         {
-          vertex_order.push_back(u);
-          is_node_stable[u] = false;
+          // If the neighbour was stable and is not in the new community, we
+          // should mark it as unstable, and add it to the queue, skipping
+          // fixed nodes
+          if (is_node_stable[u] && partitions[0]->membership(u) != max_comm && constrained_partition->membership(u) == constrained_partition->membership(v))
+          {
+            vertex_order.push_back(u);
+            is_node_stable[u] = false;
+          }
         }
       }
 

--- a/src/leidenalg/SignificanceVertexPartition.cpp
+++ b/src/leidenalg/SignificanceVertexPartition.cpp
@@ -111,8 +111,12 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
 
     // Calculate actual diff
 
-    diff =   ((double)N_oldx*KLL(q_oldx, p) - (double)N_new*KLL(q_new,  p))
-           + ((double)N_newx*KLL(q_newx, p) - (double)N_old*KLL(q_old,  p));
+    if (N_oldx != N_new || q_oldx != q_new)
+      diff +=  (double)N_oldx*KLL(q_oldx, p) - (double)N_new*KLL(q_new,  p);
+
+    if (N_newx != N_old || q_newx != q_old)
+      diff += (double)N_newx*KLL(q_newx, p) - (double)N_old*KLL(q_old,  p);
+
     #ifdef DEBUG
       cerr << "\t" << "diff: " << diff << "." << endl;
     #endif

--- a/src/leidenalg/SignificanceVertexPartition.cpp
+++ b/src/leidenalg/SignificanceVertexPartition.cpp
@@ -110,8 +110,8 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
 
     // Calculate actual diff
 
-    diff =   (double)N_oldx*KLL(q_oldx, p) + (double)N_newx*KLL(q_newx, p)
-           - (double)N_old *KLL(q_old,  p) - (double)N_new *KLL(q_new,  p);
+    diff =   ((double)N_oldx*KLL(q_oldx, p) - (double)N_new *KLL(q_new,  p))
+           + ((double)N_newx*KLL(q_newx, p) - (double)N_old *KLL(q_old,  p)) ;
     #ifdef DEBUG
       cerr << "\t" << "diff: " << diff << "." << endl;
     #endif

--- a/src/leidenalg/SignificanceVertexPartition.cpp
+++ b/src/leidenalg/SignificanceVertexPartition.cpp
@@ -29,6 +29,7 @@ SignificanceVertexPartition* SignificanceVertexPartition::create(Graph* graph, v
 SignificanceVertexPartition::~SignificanceVertexPartition()
 { }
 
+#define DEBUG
 double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
 {
   #ifdef DEBUG
@@ -110,8 +111,8 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
 
     // Calculate actual diff
 
-    diff =   ((double)N_oldx*KLL(q_oldx, p) - (double)N_new *KLL(q_new,  p))
-           + ((double)N_newx*KLL(q_newx, p) - (double)N_old *KLL(q_old,  p)) ;
+    diff =   ((double)N_oldx*KLL(q_oldx, p) - (double)N_new*KLL(q_new,  p))
+           + ((double)N_newx*KLL(q_newx, p) - (double)N_old*KLL(q_old,  p));
     #ifdef DEBUG
       cerr << "\t" << "diff: " << diff << "." << endl;
     #endif
@@ -122,6 +123,7 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
   #endif
   return diff;
 }
+#undef DEBUG
 
 /********************************************************************************
    Calculate the significance of the partition.

--- a/src/leidenalg/python_optimiser_interface.cpp
+++ b/src/leidenalg/python_optimiser_interface.cpp
@@ -404,11 +404,11 @@ extern "C"
     #endif
 
     #ifdef DEBUG
-      cerr << "Capsule constrained partition at address " << py_partition << endl;
+      cerr << "Capsule constrained partition at address " << py_constrained_partition << endl;
     #endif
     MutableVertexPartition* constrained_partition = decapsule_MutableVertexPartition(py_constrained_partition);
     #ifdef DEBUG
-      cerr << "Using constrained partition at address " << partition << endl;
+      cerr << "Using constrained partition at address " << constrained_partition << endl;
     #endif
 
     if (consider_comms < 0)


### PR DESCRIPTION
Previously, neighbouring nodes were only considered for the first graph in case of multilayer graphs for the `move_nodes` function. Additionally, neighbouring nodes were insufficiently considered. Moreover, in the case of `move_nodes_constrained`, some objects were incorrectly not initalized, leading to the bug noted in #68. To avoid future confusion, the object referring typically to the first partition and graph are explicitly removed. This fixes #68.

Presumably, this change will increase the runtime somewhat, but is likely to also lead to better quality. This needs to be analysed a bit further still.