### PR TITLE
Significance numerical stability

### DIFF
--- a/src/leidenalg/Optimiser.cpp
+++ b/src/leidenalg/Optimiser.cpp
@@ -645,7 +645,7 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
     #endif
 
     size_t max_comm = v_comm;
-    double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : DBL_EPSILON;
+    double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 10*DBL_EPSILON;
     size_t v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
@@ -1118,7 +1118,7 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
     #endif
 
     size_t max_comm = v_comm;
-    double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : DBL_EPSILON;
+    double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 10*DBL_EPSILON;
     size_t v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {

--- a/src/leidenalg/SignificanceVertexPartition.cpp
+++ b/src/leidenalg/SignificanceVertexPartition.cpp
@@ -29,6 +29,7 @@ SignificanceVertexPartition* SignificanceVertexPartition::create(Graph* graph, v
 SignificanceVertexPartition::~SignificanceVertexPartition()
 { }
 
+#define DEBUG
 double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
 {
   #ifdef DEBUG
@@ -126,6 +127,7 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
   #endif
   return diff;
 }
+#undef DEBUG
 
 /********************************************************************************
    Calculate the significance of the partition.

--- a/src/leidenalg/SignificanceVertexPartition.cpp
+++ b/src/leidenalg/SignificanceVertexPartition.cpp
@@ -29,7 +29,6 @@ SignificanceVertexPartition* SignificanceVertexPartition::create(Graph* graph, v
 SignificanceVertexPartition::~SignificanceVertexPartition()
 { }
 
-#define DEBUG
 double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
 {
   #ifdef DEBUG
@@ -127,7 +126,6 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
   #endif
   return diff;
 }
-#undef DEBUG
 
 /********************************************************************************
    Calculate the significance of the partition.


### PR DESCRIPTION
Since the fix is #70, it seems that some numerical problems sometimes lead to an infinite loop when using Significance, especially in the Linux i686 build. The current attempts at correcting this in 4165e83a681a12b4efe7f51481be24ddc6ee257e, 5f075b454e5516021df229276c31d3dda9ef306a and 65cf652263b0ccb8e6f88f94d9efc93b94a69d9a. In order to avoid cluttering the `master` branch, I will attempt to fix this in this branch (which needs to be a PR in order to trigger the CI—although it is convenient for documenting this also).