### PR TITLE
Introduce GeneralizedModularity

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,6 +6,7 @@ include/CPMVertexPartition.h
 include/GraphHelper.h
 include/LinearResolutionParameterVertexPartition.h
 include/ModularityVertexPartition.h
+include/GeneralizedModularityVertexPartition.h
 include/MutableVertexPartition.h
 include/Optimiser.h
 include/RBConfigurationVertexPartition.h
@@ -17,6 +18,7 @@ src/CPMVertexPartition.cpp
 src/GraphHelper.cpp
 src/LinearResolutionParameterVertexPartition.cpp
 src/ModularityVertexPartition.cpp
+src/GeneralizedModularityVertexPartition.cpp
 src/MutableVertexPartition.cpp
 src/Optimiser.cpp
 src/RBConfigurationVertexPartition.cpp

--- a/include/GeneralizedModularityVertexPartition.h
+++ b/include/GeneralizedModularityVertexPartition.h
@@ -12,19 +12,14 @@ class GeneralizedModularityVertexPartition : public MutableVertexPartition
     virtual ~GeneralizedModularityVertexPartition();
     virtual GeneralizedModularityVertexPartition* create(Graph* graph);
     virtual GeneralizedModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership);
-    virtual GeneralizedModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities);
+    virtual GeneralizedModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapsed_communities);
     vector<vector<double> > null_model;
 
     virtual double diff_move(size_t v, size_t new_comm);
     virtual double quality();
 
   protected:
-    virtual vector<vector<double> > _collapse_null_models(Graph* graph, vector< vector<size_t> > communities);
-
   private:
-    vector<vector<double> > _comm_loss_vectors;
-    vector <double> _node_weight_to_communities;
-    size_t _n_null_models;
 
 };
 

--- a/include/GeneralizedModularityVertexPartition.h
+++ b/include/GeneralizedModularityVertexPartition.h
@@ -18,6 +18,7 @@ class GeneralizedModularityVertexPartition : public MutableVertexPartition
     virtual double diff_move(size_t v, size_t new_comm);
     virtual double quality();
 
+    int need_collapsed_partition = 1;
   protected:
   private:
 

--- a/include/GeneralizedModularityVertexPartition.h
+++ b/include/GeneralizedModularityVertexPartition.h
@@ -12,13 +12,14 @@ class GeneralizedModularityVertexPartition : public MutableVertexPartition
     virtual ~GeneralizedModularityVertexPartition();
     virtual GeneralizedModularityVertexPartition* create(Graph* graph);
     virtual GeneralizedModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership);
+    virtual GeneralizedModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities);
     vector<vector<double> > null_model;
 
     virtual double diff_move(size_t v, size_t new_comm);
     virtual double quality();
 
   protected:
-    virtual void init_comm_loss_vectors();
+    virtual vector<vector<double> > _collapse_null_models(Graph* graph, vector< vector<size_t> > communities);
 
   private:
     vector<vector<double> > _comm_loss_vectors;

--- a/include/GeneralizedModularityVertexPartition.h
+++ b/include/GeneralizedModularityVertexPartition.h
@@ -1,0 +1,30 @@
+#ifndef GENERALIZEDMODULARITYVERTEXPARTITION_H
+#define GENERALIZEDMODULARITYVERTEXPARTITION_H
+
+#include <MutableVertexPartition.h>
+
+class GeneralizedModularityVertexPartition : public MutableVertexPartition
+{
+  public:
+    GeneralizedModularityVertexPartition(Graph* graph,
+        vector<size_t> const& membership, vector<vector<double> > const& null_model);
+    GeneralizedModularityVertexPartition(Graph* graph, vector<vector<double> > const& null_model);
+    virtual ~GeneralizedModularityVertexPartition();
+    virtual GeneralizedModularityVertexPartition* create(Graph* graph);
+    virtual GeneralizedModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership);
+    vector<vector<double> > null_model;
+
+    virtual double diff_move(size_t v, size_t new_comm);
+    virtual double quality();
+
+  protected:
+    virtual void init_comm_loss_vectors();
+
+  private:
+    vector<vector<double> > _comm_loss_vectors;
+    vector <double> _node_weight_to_communities;
+    size_t _n_null_models;
+
+};
+
+#endif //GENERALIZEDMODULARITYVERTEXPARTITION_H

--- a/include/ModularityVertexPartition.h
+++ b/include/ModularityVertexPartition.h
@@ -12,6 +12,7 @@ class ModularityVertexPartition : public MutableVertexPartition
     virtual ~ModularityVertexPartition();
     virtual ModularityVertexPartition* create(Graph* graph);
     virtual ModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership);
+    virtual ModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapased_communities);
 
     virtual double diff_move(size_t v, size_t new_comm);
     virtual double quality();

--- a/include/ModularityVertexPartition.h
+++ b/include/ModularityVertexPartition.h
@@ -12,7 +12,6 @@ class ModularityVertexPartition : public MutableVertexPartition
     virtual ~ModularityVertexPartition();
     virtual ModularityVertexPartition* create(Graph* graph);
     virtual ModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership);
-    virtual ModularityVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapased_communities);
 
     virtual double diff_move(size_t v, size_t new_comm);
     virtual double quality();

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -50,6 +50,7 @@ class MutableVertexPartition
     MutableVertexPartition(Graph* graph);
     virtual MutableVertexPartition* create(Graph* graph);
     virtual MutableVertexPartition* create(Graph* graph, vector<size_t> const& membership);
+    virtual MutableVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities);
 
     virtual ~MutableVertexPartition();
 

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -50,7 +50,7 @@ class MutableVertexPartition
     MutableVertexPartition(Graph* graph);
     virtual MutableVertexPartition* create(Graph* graph);
     virtual MutableVertexPartition* create(Graph* graph, vector<size_t> const& membership);
-    virtual MutableVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities);
+    virtual MutableVertexPartition* create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapased_communities);
 
     virtual ~MutableVertexPartition();
 

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -135,6 +135,9 @@ class MutableVertexPartition
     // we no longer have to worry about deleting this graph.
     int destructor_delete_graph;
 
+    int need_collapsed_partition = 0;
+
+
   protected:
 
     void init_admin();

--- a/include/pynterface.h
+++ b/include/pynterface.h
@@ -5,6 +5,7 @@
 #include <igraph.h>
 #include "GraphHelper.h"
 #include "ModularityVertexPartition.h"
+#include "GeneralizedModularityVertexPartition.h"
 #include "SignificanceVertexPartition.h"
 #include "SurpriseVertexPartition.h"
 #include "RBConfigurationVertexPartition.h"
@@ -25,6 +26,7 @@ extern "C"
   static PyMethodDef leiden_funcs[] = {
 
       {"_new_ModularityVertexPartition",                            (PyCFunction)_new_ModularityVertexPartition,                            METH_VARARGS | METH_KEYWORDS, ""},
+      {"_new_GeneralizedModularityVertexPartition",                  (PyCFunction)_new_GeneralizedModularityVertexPartition,                 METH_VARARGS | METH_KEYWORDS, ""},
       {"_new_SignificanceVertexPartition",                          (PyCFunction)_new_SignificanceVertexPartition,                          METH_VARARGS | METH_KEYWORDS, ""},
       {"_new_SurpriseVertexPartition",                              (PyCFunction)_new_SurpriseVertexPartition,                              METH_VARARGS | METH_KEYWORDS, ""},
       {"_new_CPMVertexPartition",                                   (PyCFunction)_new_CPMVertexPartition,                                   METH_VARARGS | METH_KEYWORDS, ""},

--- a/include/python_optimiser_interface.h
+++ b/include/python_optimiser_interface.h
@@ -5,6 +5,7 @@
 #include <igraph.h>
 #include "GraphHelper.h"
 #include "ModularityVertexPartition.h"
+#include "GeneralizedModularityVertexPartition.h"
 #include "SignificanceVertexPartition.h"
 #include "SurpriseVertexPartition.h"
 #include "RBConfigurationVertexPartition.h"

--- a/include/python_partition_interface.h
+++ b/include/python_partition_interface.h
@@ -5,6 +5,7 @@
 #include <igraph.h>
 #include "GraphHelper.h"
 #include "ModularityVertexPartition.h"
+#include "GeneralizedModularityVertexPartition.h"
 #include "SignificanceVertexPartition.h"
 #include "SurpriseVertexPartition.h"
 #include "RBConfigurationVertexPartition.h"
@@ -39,6 +40,7 @@ extern "C"
 {
 #endif
   PyObject* _new_ModularityVertexPartition(PyObject *self, PyObject *args, PyObject *keywds);
+  PyObject* _new_GeneralizedModularityVertexPartition(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _new_SignificanceVertexPartition(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _new_SurpriseVertexPartition(PyObject *self, PyObject *args, PyObject *keywds);
   PyObject* _new_CPMVertexPartition(PyObject *self, PyObject *args, PyObject *keywds);

--- a/src/leidenalg/GeneralizedModularityVertexPartition.cpp
+++ b/src/leidenalg/GeneralizedModularityVertexPartition.cpp
@@ -1,12 +1,13 @@
 #include "GeneralizedModularityVertexPartition.h"
+/**
+ * Generalised modularity relaxes the conditions between the adjacency matrix and the null model, thus one needs to keep track of the null model, and in particular accross graph collapsing.
+ */
 
 GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph* graph,
       vector<size_t> const& membership, vector<vector<double> > const& null_model) :
-        MutableVertexPartition(graph,
-        membership)
+        MutableVertexPartition(graph, membership)
 {
   this->null_model = null_model;
-  this->_n_null_models = null_model.size();
 }
 
 GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph* graph,
@@ -14,9 +15,7 @@ GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph
         MutableVertexPartition(graph)
 {
   this->null_model = null_model;
-  this->_n_null_models = null_model.size();
 }
-
 
 GeneralizedModularityVertexPartition::~GeneralizedModularityVertexPartition()
 { }
@@ -31,42 +30,46 @@ GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::crea
   return new GeneralizedModularityVertexPartition(graph, membership, this->null_model);
 }
 
-
-GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities)
+/**
+ * This constructor is necessary to be able to collapse the null model in the same way the graph is collapsed during optimisation.
+ */
+GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapsed_communities)
 {
-  vector<vector<double> > null_model = this->_collapse_null_models(graph, communities);
-  return new GeneralizedModularityVertexPartition(graph, membership, null_model);
-}
-
-vector<vector <double> > GeneralizedModularityVertexPartition::_collapse_null_models(Graph* graph, vector< vector<size_t> > communities)
-{
-    vector<vector<double> > null_model;
-    null_model.clear();
-    null_model.resize(this->_n_null_models);
-    for (unsigned int k = 0; k < this->_n_null_models; ++k) 
+    // collapsing null model first by summing original null_model over nodes in the same community used to collapsed the graph
+    vector<vector<double> > collapsed_null_model;
+    collapsed_null_model.clear();
+    collapsed_null_model.resize(this->null_model.size());
+    for (unsigned int k = 0; k < this->null_model.size(); ++k) 
     {
-      null_model[k].clear();
-      null_model[k].resize(graph->vcount());
+      collapsed_null_model[k].clear();
+      collapsed_null_model[k].resize(graph->vcount());
       for (size_t u = 0; u < graph->vcount(); ++u)
       {
-        vector<size_t> comm = communities[u];
+        vector<size_t> comm = collapsed_communities[u];
         for (size_t v = 0; v < comm.size(); ++v){
-            null_model[k][u] += this->null_model[k][comm[v]];
+            collapsed_null_model[k][u] += this->null_model[k][comm[v]];
         }
       }
     }
-    return null_model;
+ 
+  return new GeneralizedModularityVertexPartition(graph, membership, null_model);
 }
 
+/**
+ * Computes the difference in generalized modularity by moving a node v into another community new_comm
+ */
 double GeneralizedModularityVertexPartition::diff_move(size_t v, size_t new_comm)
 {
   double loss = 0;
   double gain = 0;
 
   size_t old_comm = this->_membership[v];
+
+  // if we do not move to another community, quality does not change
   if (new_comm == old_comm)
       return 0.0;
-  
+ 
+  // compute the loss to remove from old_comm and gain to move to new_comm for quality matrix
   double w_to_old = this->weight_to_comm(v, old_comm);
   double w_from_old = this->weight_from_comm(v, old_comm);
   double w_to_new = this->weight_to_comm(v, new_comm);
@@ -75,56 +78,59 @@ double GeneralizedModularityVertexPartition::diff_move(size_t v, size_t new_comm
 
   loss = w_to_old + w_from_old;
   gain = w_to_new + w_from_new + 2 * self_weight;
-
-  for (size_t u = 0; u < this->graph->vcount(); ++u){
+    
+  // compute the gain and loss for null model
+  for (size_t u = 0; u < this->graph->vcount(); ++u)
+  {
     size_t u_comm = this->_membership[u];
-    if (u_comm == old_comm){
-      for (size_t m = 0; m < this->_n_null_models; m = m + 2) {
+    if (u_comm == old_comm)
+      for (size_t m = 0; m < this->null_model.size(); m = m + 2) 
+      {
         loss -= this->null_model[m][u] * this->null_model[m + 1][v];
         loss -= this->null_model[m][v] * this->null_model[m + 1][u];
       }
-    }
-    if (u_comm == new_comm){
-      for (size_t m = 0; m < this->_n_null_models; m = m + 2) {
+    if (u_comm == new_comm)
+      for (size_t m = 0; m < this->null_model.size(); m = m + 2) 
+      {
         gain -= this->null_model[m][u] * this->null_model[m + 1][v];
         gain -= this->null_model[m][v] * this->null_model[m + 1][u];
       }
-    }
   }
 
-  for (size_t m = 0; m < this->_n_null_models; m = m + 2) {
+  // we also need to add the contribution of the added node to the new_comm
+  for (size_t m = 0; m < this->null_model.size(); m = m + 2) 
+  {
     gain -= this->null_model[m][v] * this->null_model[m + 1][v];
     gain -= this->null_model[m][v] * this->null_model[m + 1][v];
   }
+
   return gain - loss;
 }
 
-
+/**
+ * Compute the quality function of the generalized modularity.
+ */
 double GeneralizedModularityVertexPartition::quality()
 {
-  double mod = 0.0;
   vector<double> mod_null;
   mod_null.clear();
   mod_null.resize(this->n_communities());
-
+    
+  // compute the contribution from null model
   size_t n = this->graph->vcount();
   for (size_t u = 0; u < n; ++u)
-  {
     for (size_t v = 0; v < n; ++v)
      {
         size_t u_comm = this->_membership[u];
         size_t v_comm = this->_membership[v];
         if (u_comm == v_comm)
-        {
-          for (size_t m = 0; m < this->_n_null_models; m = m + 2) 
+          for (size_t m = 0; m < this->null_model.size(); m = m + 2) 
             mod_null[u_comm] += this->null_model[m][u] * this->null_model[m + 1][v];
-        }
      }
-  }
 
+  // compute quality
+  double gen_mod = 0.0;
   for (size_t c = 0; c < this->n_communities(); ++c)
-  {
-    mod += this->total_weight_in_comm(c) - mod_null[c];
-  }
-  return mod;
+    gen_mod += this->total_weight_in_comm(c) - mod_null[c];
+  return gen_mod;
 }

--- a/src/leidenalg/GeneralizedModularityVertexPartition.cpp
+++ b/src/leidenalg/GeneralizedModularityVertexPartition.cpp
@@ -1,0 +1,118 @@
+#include "GeneralizedModularityVertexPartition.h"
+
+#ifdef DEBUG
+#include <iostream>
+using std::cerr;
+using std::endl;
+#endif
+
+GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph* graph,
+      vector<size_t> const& membership, vector<vector<double> > const& null_model) :
+        MutableVertexPartition(graph,
+        membership)
+{
+  this->null_model = null_model;
+  this->_n_null_models = null_model.size();
+  this->init_comm_loss_vectors();
+}
+
+GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph* graph,
+      vector<vector<double> > const& null_model) :
+        MutableVertexPartition(graph)
+{
+  this->null_model = null_model;
+  this->_n_null_models = null_model.size();
+  this->init_comm_loss_vectors();
+}
+
+
+GeneralizedModularityVertexPartition::~GeneralizedModularityVertexPartition()
+{ }
+
+GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::create(Graph* graph)
+{
+  return new GeneralizedModularityVertexPartition(graph, this->null_model);
+}
+
+GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::create(Graph* graph, vector<size_t> const& membership)
+{
+  return new GeneralizedModularityVertexPartition(graph, membership, this->null_model);
+}
+
+// compute comm_loss_vectors for diff_move computation
+void GeneralizedModularityVertexPartition::init_comm_loss_vectors()
+{
+
+  this->_comm_loss_vectors.clear();
+  this->_comm_loss_vectors.resize(this->_n_null_models);
+  for (unsigned int k = 0; k < this->_n_null_models; ++k) 
+  {
+    this->_comm_loss_vectors[k].clear();
+    this->_comm_loss_vectors[k].resize(this->n_communities());
+    for (size_t v = 0; v < graph->vcount(); v++)
+    {
+      this->_comm_loss_vectors[k][this->_membership[v]] += this->null_model[k][v];
+    }
+  }
+}
+
+/*****************************************************************************
+  Returns the difference in modularity if we move a node to a new community
+*****************************************************************************/
+double GeneralizedModularityVertexPartition::diff_move(size_t v, size_t new_comm)
+{
+
+  double comm_loss = 0;
+  for (unsigned int m = 0; m < this->_n_null_models; m = m + 2) {
+    comm_loss += this->null_model[m][v] * this->_comm_loss_vectors[m + 1][new_comm] 
+        + null_model[m + 1][v] * this->_comm_loss_vectors[m][new_comm];
+  }
+
+  this->_node_weight_to_communities.clear();
+  this->_node_weight_to_communities.resize(this->n_communities());
+
+  vector<size_t> const& neighbours = this->graph->get_neighbours(v, IGRAPH_ALL);
+  vector<size_t> const& neighbour_edges = this->graph->get_neighbour_edges(v, IGRAPH_ALL);
+  for (size_t idx = 0; idx < neighbours.size(); idx++)
+  {
+    size_t u_comm = this->_membership[neighbours[idx]];
+    this->_node_weight_to_communities[u_comm] += this->graph->edge_weight(neighbour_edges[idx]);
+  }
+   return 2 * this->_node_weight_to_communities[new_comm] - comm_loss;
+}
+
+
+/*****************************************************************************
+  Give the generalized modularity of the partition.
+******************************************************************************/
+double GeneralizedModularityVertexPartition::quality()
+{
+  double mod = 0.0;
+  vector<double> mod_null;
+  mod_null.clear();
+  mod_null.resize(this->n_communities());
+
+  size_t n = graph->vcount();
+  for (size_t u = 0; u < n; u++)
+  {
+    for (size_t v = 0; v < n; v++)
+     {
+        size_t u_comm = this->_membership[u];
+        size_t v_comm = this->_membership[v];
+        if (u_comm == v_comm)
+        {
+          // we sum over nul models which come in pairs
+          for (size_t m = 0; m < this->_n_null_models; m = m + 2) 
+          {
+            mod_null[u_comm] += this->null_model[m][u] * this->null_model[m + 1][v];
+          }
+        }
+     }
+  }
+
+  for (size_t c = 0; c < this->n_communities(); c++)
+  {
+    mod += 2 * this->total_weight_in_comm(c) - mod_null[c];
+  }
+  return mod;
+}

--- a/src/leidenalg/GeneralizedModularityVertexPartition.cpp
+++ b/src/leidenalg/GeneralizedModularityVertexPartition.cpp
@@ -1,11 +1,5 @@
 #include "GeneralizedModularityVertexPartition.h"
 
-#ifdef DEBUG
-#include <iostream>
-using std::cerr;
-using std::endl;
-#endif
-
 GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph* graph,
       vector<size_t> const& membership, vector<vector<double> > const& null_model) :
         MutableVertexPartition(graph,
@@ -13,7 +7,6 @@ GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph
 {
   this->null_model = null_model;
   this->_n_null_models = null_model.size();
-  this->init_comm_loss_vectors();
 }
 
 GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph* graph,
@@ -22,7 +15,6 @@ GeneralizedModularityVertexPartition::GeneralizedModularityVertexPartition(Graph
 {
   this->null_model = null_model;
   this->_n_null_models = null_model.size();
-  this->init_comm_loss_vectors();
 }
 
 
@@ -39,52 +31,75 @@ GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::crea
   return new GeneralizedModularityVertexPartition(graph, membership, this->null_model);
 }
 
-// compute comm_loss_vectors for diff_move computation
-void GeneralizedModularityVertexPartition::init_comm_loss_vectors()
-{
 
-  this->_comm_loss_vectors.clear();
-  this->_comm_loss_vectors.resize(this->_n_null_models);
-  for (unsigned int k = 0; k < this->_n_null_models; ++k) 
-  {
-    this->_comm_loss_vectors[k].clear();
-    this->_comm_loss_vectors[k].resize(this->n_communities());
-    for (size_t v = 0; v < graph->vcount(); v++)
-    {
-      this->_comm_loss_vectors[k][this->_membership[v]] += this->null_model[k][v];
-    }
-  }
+GeneralizedModularityVertexPartition* GeneralizedModularityVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities)
+{
+  vector<vector<double> > null_model = this->_collapse_null_models(graph, communities);
+  return new GeneralizedModularityVertexPartition(graph, membership, null_model);
 }
 
-/*****************************************************************************
-  Returns the difference in modularity if we move a node to a new community
-*****************************************************************************/
+vector<vector <double> > GeneralizedModularityVertexPartition::_collapse_null_models(Graph* graph, vector< vector<size_t> > communities)
+{
+    vector<vector<double> > null_model;
+    null_model.clear();
+    null_model.resize(this->_n_null_models);
+    for (unsigned int k = 0; k < this->_n_null_models; ++k) 
+    {
+      null_model[k].clear();
+      null_model[k].resize(graph->vcount());
+      for (size_t u = 0; u < graph->vcount(); ++u)
+      {
+        vector<size_t> comm = communities[u];
+        for (size_t v = 0; v < comm.size(); ++v){
+            null_model[k][u] += this->null_model[k][comm[v]];
+        }
+      }
+    }
+    return null_model;
+}
+
 double GeneralizedModularityVertexPartition::diff_move(size_t v, size_t new_comm)
 {
+  double loss = 0;
+  double gain = 0;
 
-  double comm_loss = 0;
-  for (unsigned int m = 0; m < this->_n_null_models; m = m + 2) {
-    comm_loss += this->null_model[m][v] * this->_comm_loss_vectors[m + 1][new_comm] 
-        + null_model[m + 1][v] * this->_comm_loss_vectors[m][new_comm];
+  size_t old_comm = this->_membership[v];
+  if (new_comm == old_comm)
+      return 0.0;
+  
+  double w_to_old = this->weight_to_comm(v, old_comm);
+  double w_from_old = this->weight_from_comm(v, old_comm);
+  double w_to_new = this->weight_to_comm(v, new_comm);
+  double w_from_new = this->weight_from_comm(v, new_comm);
+  double self_weight = this->graph->node_self_weight(v);
+
+  loss = w_to_old + w_from_old;
+  gain = w_to_new + w_from_new + 2 * self_weight;
+
+  for (size_t u = 0; u < this->graph->vcount(); ++u){
+    size_t u_comm = this->_membership[u];
+    if (u_comm == old_comm){
+      for (size_t m = 0; m < this->_n_null_models; m = m + 2) {
+        loss -= this->null_model[m][u] * this->null_model[m + 1][v];
+        loss -= this->null_model[m][v] * this->null_model[m + 1][u];
+      }
+    }
+    if (u_comm == new_comm){
+      for (size_t m = 0; m < this->_n_null_models; m = m + 2) {
+        gain -= this->null_model[m][u] * this->null_model[m + 1][v];
+        gain -= this->null_model[m][v] * this->null_model[m + 1][u];
+      }
+    }
   }
 
-  this->_node_weight_to_communities.clear();
-  this->_node_weight_to_communities.resize(this->n_communities());
-
-  vector<size_t> const& neighbours = this->graph->get_neighbours(v, IGRAPH_ALL);
-  vector<size_t> const& neighbour_edges = this->graph->get_neighbour_edges(v, IGRAPH_ALL);
-  for (size_t idx = 0; idx < neighbours.size(); idx++)
-  {
-    size_t u_comm = this->_membership[neighbours[idx]];
-    this->_node_weight_to_communities[u_comm] += this->graph->edge_weight(neighbour_edges[idx]);
+  for (size_t m = 0; m < this->_n_null_models; m = m + 2) {
+    gain -= this->null_model[m][v] * this->null_model[m + 1][v];
+    gain -= this->null_model[m][v] * this->null_model[m + 1][v];
   }
-   return 2 * this->_node_weight_to_communities[new_comm] - comm_loss;
+  return gain - loss;
 }
 
 
-/*****************************************************************************
-  Give the generalized modularity of the partition.
-******************************************************************************/
 double GeneralizedModularityVertexPartition::quality()
 {
   double mod = 0.0;
@@ -92,27 +107,24 @@ double GeneralizedModularityVertexPartition::quality()
   mod_null.clear();
   mod_null.resize(this->n_communities());
 
-  size_t n = graph->vcount();
-  for (size_t u = 0; u < n; u++)
+  size_t n = this->graph->vcount();
+  for (size_t u = 0; u < n; ++u)
   {
-    for (size_t v = 0; v < n; v++)
+    for (size_t v = 0; v < n; ++v)
      {
         size_t u_comm = this->_membership[u];
         size_t v_comm = this->_membership[v];
         if (u_comm == v_comm)
         {
-          // we sum over nul models which come in pairs
           for (size_t m = 0; m < this->_n_null_models; m = m + 2) 
-          {
             mod_null[u_comm] += this->null_model[m][u] * this->null_model[m + 1][v];
-          }
         }
      }
   }
 
-  for (size_t c = 0; c < this->n_communities(); c++)
+  for (size_t c = 0; c < this->n_communities(); ++c)
   {
-    mod += 2 * this->total_weight_in_comm(c) - mod_null[c];
+    mod += this->total_weight_in_comm(c) - mod_null[c];
   }
   return mod;
 }

--- a/src/leidenalg/ModularityVertexPartition.cpp
+++ b/src/leidenalg/ModularityVertexPartition.cpp
@@ -29,6 +29,12 @@ ModularityVertexPartition* ModularityVertexPartition::create(Graph* graph, vecto
   return new ModularityVertexPartition(graph, membership);
 }
 
+ModularityVertexPartition* ModularityVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapased_communities)
+{
+  return new ModularityVertexPartition(graph, membership);
+}
+
+
 /*****************************************************************************
   Returns the difference in modularity if we move a node to a new community
 *****************************************************************************/

--- a/src/leidenalg/ModularityVertexPartition.cpp
+++ b/src/leidenalg/ModularityVertexPartition.cpp
@@ -29,11 +29,6 @@ ModularityVertexPartition* ModularityVertexPartition::create(Graph* graph, vecto
   return new ModularityVertexPartition(graph, membership);
 }
 
-ModularityVertexPartition* ModularityVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapased_communities)
-{
-  return new ModularityVertexPartition(graph, membership);
-}
-
 
 /*****************************************************************************
   Returns the difference in modularity if we move a node to a new community

--- a/src/leidenalg/MutableVertexPartition.cpp
+++ b/src/leidenalg/MutableVertexPartition.cpp
@@ -59,6 +59,12 @@ MutableVertexPartition* MutableVertexPartition::create(Graph* graph, vector<size
   return new MutableVertexPartition(graph, membership);
 }
 
+MutableVertexPartition* MutableVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities)
+{
+  return new MutableVertexPartition(graph, membership);
+}
+
+
 
 MutableVertexPartition::~MutableVertexPartition()
 {

--- a/src/leidenalg/MutableVertexPartition.cpp
+++ b/src/leidenalg/MutableVertexPartition.cpp
@@ -59,7 +59,7 @@ MutableVertexPartition* MutableVertexPartition::create(Graph* graph, vector<size
   return new MutableVertexPartition(graph, membership);
 }
 
-MutableVertexPartition* MutableVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > communities)
+MutableVertexPartition* MutableVertexPartition::create(Graph* graph, vector<size_t> const& membership, vector< vector<size_t> > collapsed_communities)
 {
   return new MutableVertexPartition(graph, membership);
 }

--- a/src/leidenalg/Optimiser.cpp
+++ b/src/leidenalg/Optimiser.cpp
@@ -268,8 +268,8 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
       // Create new collapsed partition
       for (size_t layer = 0; layer < nb_layers; layer++)
       {
+        new_collapsed_partitions[layer] = collapsed_partitions[layer]->create(new_collapsed_graphs[layer], new_collapsed_membership, sub_collapsed_partitions[layer]->get_communities());
         delete sub_collapsed_partitions[layer];
-        new_collapsed_partitions[layer] = collapsed_partitions[layer]->create(new_collapsed_graphs[layer], new_collapsed_membership);
       }
     }
     else

--- a/src/leidenalg/Optimiser.cpp
+++ b/src/leidenalg/Optimiser.cpp
@@ -268,7 +268,10 @@ double Optimiser::optimise_partition(vector<MutableVertexPartition*> partitions,
       // Create new collapsed partition
       for (size_t layer = 0; layer < nb_layers; layer++)
       {
-        new_collapsed_partitions[layer] = collapsed_partitions[layer]->create(new_collapsed_graphs[layer], new_collapsed_membership, sub_collapsed_partitions[layer]->get_communities());
+        if (collapsed_partitions[layer]->need_collapsed_partition)
+            new_collapsed_partitions[layer] = collapsed_partitions[layer]->create(new_collapsed_graphs[layer], new_collapsed_membership, sub_collapsed_partitions[layer]->get_communities());
+        else
+            new_collapsed_partitions[layer] = collapsed_partitions[layer]->create(new_collapsed_graphs[layer], new_collapsed_membership);
         delete sub_collapsed_partitions[layer];
       }
     }

--- a/src/leidenalg/VertexPartition.py
+++ b/src/leidenalg/VertexPartition.py
@@ -1101,48 +1101,31 @@ class CPMVertexPartition(LinearResolutionParameterVertexPartition):
                      resolution_parameter=resolution_parameter_01 - resolution_parameter_1)
     return partition_01, partition_0, partition_1
 
+
 class GeneralizedModularityVertexPartition(MutableVertexPartition):
-  """ Implements modularity. This quality function is well-defined only for positive edge weights.
+  """ Implements generalized modularity, well-defined only for positive edge weights.
 
   Notes
   -----
   The quality function is
 
-  .. math:: Q = \\frac{1}{2m} \\sum_{ij} \\left(A_{ij} - \\frac{k_i k_j}{2m} \\right)\\delta(\\sigma_i, \\sigma_j)
+  .. math:: Q = \\sum_{ij} \\left(F_{ij} - \\sum_{k}v_{2k, i} v_{2k+1, j} \\right)\\delta(\\sigma_i, \\sigma_j)
 
-  where :math:`A` is the adjacency matrix, :math:`k_i` is the (weighted) degree
-  of node :math:`i`, :math:`m` is the total number of edges (or total edge
-  weight), :math:`\\sigma_i` denotes the community of node :math:`i` and
+  where :math:`F` is a quality matrix, such as adjacency, or any other representations,
+  :math:`v_{k}` are null model vectors, which generalise the weighted degree vectors of modularity.
+  :math:`\\sigma_i` denotes the community of node :math:`i` and
   :math:`\\delta(\\sigma_i, \\sigma_j) = 1` if :math:`\\sigma_i = \\sigma_j`
   and `0` otherwise.
 
-  This can alternatively be formulated as a sum over communities:
-
-  .. math:: Q = \\frac{1}{2m} \\sum_{c} \\left(m_c - \\frac{K_c^2}{4m} \\right)
-
-  where :math:`m_c` is the number of internal edges (or total internal edge
-  weight) of community :math:`c` and :math:`K_c = \\sum_{i \\mid \\sigma_i = c}
-  k_i` is the total (weighted) degree of nodes in community :math:`c`.
-
-  Note that for directed graphs a slightly different formulation is used, as
-  proposed by Leicht and Newman [2]:
-
-  .. math:: Q = \\frac{1}{m} \\sum_{ij} \\left(A_{ij} - \\frac{k_i^\mathrm{out} k_j^\mathrm{in}}{m} \\right)\\delta(\\sigma_i, \\sigma_j),
-
-  where :math:`k_i^\\mathrm{out}` and :math:`k_i^\\mathrm{in}` refers to
-  respectively the outdegree and indegree of node :math:`i`, and :math:`A_{ij}`
-  refers to an edge from :math:`i` to :math:`j`.
-
   References
   ----------
-  .. [1] Newman, M. E. J., & Girvan, M. (2004). Finding and evaluating
-         community structure in networks.  Physical Review E, 69(2), 026113.
-         `10.1103/PhysRevE.69.026113 <http://doi.org/10.1103/PhysRevE.69.026113>`_
+  .. [1] Schaub, M.T. & Delvenne, J.-C. & Lambiotte, R. & Barahona, M. (2019). Multiscale dynamical
+         embeddings of complex networks. Physical Review E, 99(6), 062308.
+         `doi.org/10.1103/PhysRevE.99.062308  <https://doi.org/10.1103/PhysRevE.99.062308>`_
 
-  .. [2] Leicht, E. A., & Newman, M. E. J. (2008). Community Structure
-         in Directed Networks. Physical Review Letters, 100(11), 118703.
-         `10.1103/PhysRevLett.100.118703 <https://doi.org/10.1103/PhysRevLett.100.118703>`_
+  .. [2] Pygenstability paper TO ADD
    """
+
   def __init__(self, graph, initial_membership=None, weights=None, null_model=None):
     """
     Parameters
@@ -1156,6 +1139,9 @@ class GeneralizedModularityVertexPartition(MutableVertexPartition):
 
     weights : list of double, or edge attribute
       Weights of edges. Can be either an iterable or an edge attribute.
+
+    null_model : list of list of null models, should be an even number of null models with same size
+      as number of nodes in the graph
     """
     if initial_membership is not None:
       initial_membership = list(initial_membership)

--- a/src/leidenalg/__init__.py
+++ b/src/leidenalg/__init__.py
@@ -48,6 +48,7 @@ from .functions import time_slices_to_layers
 
 from .Optimiser import Optimiser
 from .VertexPartition import ModularityVertexPartition
+from .VertexPartition import GeneralizedModularityVertexPartition
 from .VertexPartition import SurpriseVertexPartition
 from .VertexPartition import SignificanceVertexPartition
 from .VertexPartition import RBERVertexPartition

--- a/tests/test_VertexPartition.py
+++ b/tests/test_VertexPartition.py
@@ -218,6 +218,24 @@ class SignificanceVertexPartitionTest(BaseTest.MutableVertexPartitionTest):
     super(SignificanceVertexPartitionTest, self).setUp()
     self.partition_type = leidenalg.SignificanceVertexPartition
 
+"""
+class GeneralizedModularityVertexPartitionTest(BaseTest.MutableVertexPartitionTest):
+  def setUp(self):
+    super(GeneralizedModularityVertexPartitionTest, self).setUp()
+
+    def partition_type(graph, weights=None):
+        null_model = [graph.vcount()*[1.0], graph.vcount()*[1.0]]
+        print(null_model)
+        _graph = graph.copy()
+        _graph.to_directed()
+        return leidenalg.GeneralizedModularityVertexPartition(
+            _graph, weights=weights, null_model=null_model
+        )
+
+    self.partition_type = partition_type
+
+"""
+
 #%%
 if __name__ == '__main__':
   #%%


### PR DESCRIPTION
We are attempting to introduce leiden solver into Markov Stability with generalized modularity in this other repository here: https://github.com/barahona-research-group/PyGenStability/pull/43

The aim of this PR is to have the option to either use the original generalized Louvain from https://github.com/michaelschaub/generalizedLouvain or the corresponding generalized Leiden.

I'm happy to discuss more if needed here, or by other means. I work with Michael Schaub,  Mauricio Barahona and other collaborators to improve our PyGenStability package with more functionalities.