### PR TITLE
Changed node sizes to floats.

### DIFF
--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -67,30 +67,31 @@ class Graph
   public:
     Graph(igraph_t* graph,
       vector<double> const& edge_weights,
-      vector<size_t> const& node_sizes,
+      vector<double> const& node_sizes,
       vector<double> const& node_self_weights, int correct_self_loops);
     Graph(igraph_t* graph,
       vector<double> const& edge_weights,
-      vector<size_t> const& node_sizes,
+      vector<double> const& node_sizes,
       vector<double> const& node_self_weights);
     Graph(igraph_t* graph,
       vector<double> const& edge_weights,
-      vector<size_t> const& node_sizes, int correct_self_loops);
+      vector<double> const& node_sizes, int correct_self_loops);
     Graph(igraph_t* graph,
       vector<double> const& edge_weights,
-      vector<size_t> const& node_sizes);
-    Graph(igraph_t* graph, vector<double> const& edge_weights, int correct_self_loops);
-    Graph(igraph_t* graph, vector<double> const& edge_weights);
-    Graph(igraph_t* graph, vector<size_t> const& node_sizes, int correct_self_loops);
-    Graph(igraph_t* graph, vector<size_t> const& node_sizes);
+      vector<double> const& node_sizes);
     Graph(igraph_t* graph, int correct_self_loops);
     Graph(igraph_t* graph);
     Graph();
     ~Graph();
 
+    static Graph* GraphFromEdgeWeights(igraph_t* graph, vector<double> const& edge_weights, int correct_self_loops);
+    static Graph* GraphFromEdgeWeights(igraph_t* graph, vector<double> const& edge_weights);
+    static Graph* GraphFromNodeSizes(igraph_t* graph, vector<double> const& node_sizes, int correct_self_loops);
+    static Graph* GraphFromNodeSizes(igraph_t* graph, vector<double> const& node_sizes);
+
     int has_self_loops();
-    size_t possible_edges();
-    size_t possible_edges(size_t n);
+    double possible_edges();
+    double possible_edges(double n);
 
     Graph* collapse_graph(MutableVertexPartition* partition);
 
@@ -108,7 +109,7 @@ class Graph
     inline size_t vcount() { return igraph_vcount(this->_graph); };
     inline size_t ecount() { return igraph_ecount(this->_graph); };
     inline double total_weight() { return this->_total_weight; };
-    inline size_t total_size() { return this->_total_size; };
+    inline double total_size() { return this->_total_size; };
     inline int is_directed() { return this->_is_directed; };
     inline double density() { return this->_density; };
     inline int correct_self_loops() { return this->_correct_self_loops; };
@@ -137,7 +138,7 @@ class Graph
     }
 
     // Get size of node based on attribute (or 1.0 if there is none).
-    inline size_t node_size(size_t v)
+    inline double node_size(size_t v)
     { return this->_node_sizes[v]; };
 
     // Get self weight of node based on attribute (or set to 0.0 if there is none)
@@ -170,7 +171,6 @@ class Graph
 
     int _remove_graph;
 
-  private:
     igraph_t* _graph;
     igraph_vector_int_t _temp_igraph_vector;
 
@@ -183,7 +183,7 @@ class Graph
     vector<size_t> _degree_all;
 
     vector<double> _edge_weights; // Used for the weight of the edges.
-    vector<size_t> _node_sizes; // Used for the size of the nodes.
+    vector<double> _node_sizes; // Used for the size of the nodes.
     vector<double> _node_self_weights; // Used for the self weight of the nodes.
 
     void cache_neighbours(size_t v, igraph_neimode_t mode);
@@ -197,7 +197,7 @@ class Graph
     vector<size_t> _cached_neigh_edges_all;  size_t _current_node_cache_neigh_edges_all;
 
     double _total_weight;
-    size_t _total_size;
+    double _total_size;
     int _is_weighted;
     bool _is_directed;
 

--- a/include/GraphHelper.h
+++ b/include/GraphHelper.h
@@ -8,6 +8,8 @@
 #include <exception>
 #include <deque>
 
+#include <cstdbool>
+
 //#ifdef DEBUG
 #include <iostream>
   using std::cerr;

--- a/include/MutableVertexPartition.h
+++ b/include/MutableVertexPartition.h
@@ -56,7 +56,7 @@ class MutableVertexPartition
     inline size_t membership(size_t v) { return this->_membership[v]; };
     inline vector<size_t> const& membership() const { return this->_membership; };
 
-    size_t csize(size_t comm);
+    double csize(size_t comm);
     size_t cnodes(size_t comm);
     vector<size_t> get_community(size_t comm);
     vector< vector<size_t> > get_communities();
@@ -143,7 +143,7 @@ class MutableVertexPartition
     Graph* graph;
 
     // Community size
-    vector< size_t > _csize;
+    vector<double> _csize;
 
     // Number of nodes in community
     vector< size_t > _cnodes;

--- a/include/python_partition_interface.h
+++ b/include/python_partition_interface.h
@@ -25,7 +25,7 @@ MutableVertexPartition* create_partition_from_py(PyObject* py_obj_graph, char* m
 
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes);
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights);
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, int check_positive_weight);
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, bool check_positive_weight, bool correct_self_loops);
 
 vector<size_t> create_size_t_vector(PyObject* py_list);
 

--- a/src/leidenalg/CPMVertexPartition.cpp
+++ b/src/leidenalg/CPMVertexPartition.cpp
@@ -64,15 +64,15 @@ double CPMVertexPartition::diff_move(size_t v, size_t new_comm)
     #ifdef DEBUG
       cerr << "\t" << "w_from_new: " << w_from_new << endl;
     #endif
-    size_t nsize = this->graph->node_size(v);
+    double nsize = this->graph->node_size(v);
     #ifdef DEBUG
       cerr << "\t" << "nsize: " << nsize << endl;
     #endif
-    size_t csize_old = this->csize(old_comm);
+    double csize_old = this->csize(old_comm);
     #ifdef DEBUG
       cerr << "\t" << "csize_old: " << csize_old << endl;
     #endif
-    size_t csize_new = this->csize(new_comm);
+    double csize_new = this->csize(new_comm);
     #ifdef DEBUG
       cerr << "\t" << "csize_new: " << csize_new << endl;
     #endif
@@ -127,9 +127,9 @@ double CPMVertexPartition::quality(double resolution_parameter)
   double mod = 0.0;
   for (size_t c = 0; c < this->n_communities(); c++)
   {
-    size_t csize = this->csize(c);
+    double csize = this->csize(c);
     double w = this->total_weight_in_comm(c);
-    size_t comm_possible_edges = this->graph->possible_edges(csize);
+    double comm_possible_edges = this->graph->possible_edges(csize);
 
     #ifdef DEBUG
       cerr << "\t" << "Comm: " << c << ", w_c=" << w << ", n_c=" << csize << ", comm_possible_edges=" << comm_possible_edges << ", p=" << this->graph->density() << "." << endl;

--- a/src/leidenalg/GraphHelper.cpp
+++ b/src/leidenalg/GraphHelper.cpp
@@ -295,7 +295,7 @@ double Graph::possible_edges()
 
 double Graph::possible_edges(double n)
 {
-  size_t possible_edges = n*(n-1);
+  double possible_edges = n*(n-1);
   if (!this->is_directed())
     possible_edges /= 2;
   if (this->correct_self_loops())

--- a/src/leidenalg/GraphHelper.cpp
+++ b/src/leidenalg/GraphHelper.cpp
@@ -69,7 +69,7 @@ double KLL(double q, double p)
 
 Graph::Graph(igraph_t* graph,
   vector<double> const& edge_weights,
-  vector<size_t> const& node_sizes,
+  vector<double> const& node_sizes,
   vector<double> const& node_self_weights, int correct_self_loops)
 {
   this->_graph = graph;
@@ -95,7 +95,7 @@ Graph::Graph(igraph_t* graph,
 
 Graph::Graph(igraph_t* graph,
   vector<double> const& edge_weights,
-  vector<size_t> const& node_sizes,
+  vector<double> const& node_sizes,
   vector<double> const& node_self_weights)
 {
   this->_graph = graph;
@@ -119,7 +119,7 @@ Graph::Graph(igraph_t* graph,
 
 Graph::Graph(igraph_t* graph,
   vector<double> const& edge_weights,
-  vector<size_t> const& node_sizes, int correct_self_loops)
+  vector<double> const& node_sizes, int correct_self_loops)
 {
   this->_graph = graph;
   this->_remove_graph = false;
@@ -141,7 +141,7 @@ Graph::Graph(igraph_t* graph,
 
 Graph::Graph(igraph_t* graph,
   vector<double> const& edge_weights,
-  vector<size_t> const& node_sizes)
+  vector<double> const& node_sizes)
 {
   this->_graph = graph;
   this->_remove_graph = false;
@@ -161,72 +161,76 @@ Graph::Graph(igraph_t* graph,
   this->set_self_weights();
 }
 
-Graph::Graph(igraph_t* graph, vector<double> const& edge_weights, int correct_self_loops)
+Graph* Graph::GraphFromEdgeWeights(igraph_t* graph, vector<double> const& edge_weights, int correct_self_loops)
 {
-  this->_graph = graph;
-  this->_remove_graph = false;
-  this->_correct_self_loops = correct_self_loops;
-  if (edge_weights.size() != this->ecount())
+  Graph* g = new Graph(graph, correct_self_loops);
+
+  if (edge_weights.size() != g->ecount())
     throw Exception("Edge weights vector inconsistent length with the edge count of the graph.");
-  this->_edge_weights = edge_weights;
-  this->_is_weighted = true;
-  this->set_default_node_size();
-  igraph_vector_int_init(&this->_temp_igraph_vector, this->vcount());
-  this->init_admin();
-  this->set_self_weights();
+  g->_edge_weights = edge_weights;
+  g->_is_weighted = true;
+  g->set_default_node_size();
+  igraph_vector_int_init(&g->_temp_igraph_vector, g->vcount());
+  g->init_admin();
+  g->set_self_weights();
+
+  return g;
 }
 
-Graph::Graph(igraph_t* graph, vector<double> const& edge_weights)
+Graph* Graph::GraphFromEdgeWeights(igraph_t* graph, vector<double> const& edge_weights)
 {
-  this->_graph = graph;
-  this->_remove_graph = false;
-  if (edge_weights.size() != this->ecount())
+  Graph* g = new Graph(graph);
+
+  if (edge_weights.size() != g->ecount())
     throw Exception("Edge weights vector inconsistent length with the edge count of the graph.");
-  this->_edge_weights = edge_weights;
-  this->_is_weighted = true;
+  g->_edge_weights = edge_weights;
+  g->_is_weighted = true;
+  g->set_default_node_size();
+  igraph_vector_int_init(&g->_temp_igraph_vector, g->vcount());
+  g->init_admin();
+  g->set_self_weights();
 
-  this->_correct_self_loops = this->has_self_loops();
-
-  this->set_default_node_size();
-  igraph_vector_int_init(&this->_temp_igraph_vector, this->vcount());
-  this->init_admin();
-  this->set_self_weights();
+  return g;
 }
 
-Graph::Graph(igraph_t* graph, vector<size_t> const& node_sizes, int correct_self_loops)
+Graph* Graph::GraphFromNodeSizes(igraph_t* graph, vector<double> const& node_sizes, int correct_self_loops)
 {
-  this->_graph = graph;
-  this->_remove_graph = false;
-  this->_correct_self_loops = correct_self_loops;
+  Graph* g = new Graph(graph, correct_self_loops);
 
-  if (node_sizes.size() != this->vcount())
+  if (node_sizes.size() != g->vcount())
     throw Exception("Node size vector inconsistent length with the vertex count of the graph.");
-  this->_node_sizes = node_sizes;
+  g->_node_sizes = node_sizes;
 
-  this->set_default_edge_weight();
-  this->_is_weighted = false;
-  igraph_vector_int_init(&this->_temp_igraph_vector, this->vcount());
-  this->init_admin();
-  this->set_self_weights();
+  g->set_default_edge_weight();
+  g->_is_weighted = false;
+  igraph_vector_int_init(&g->_temp_igraph_vector, g->vcount());
+  g->init_admin();
+  g->set_self_weights();
+  
+  return g;
 }
 
-Graph::Graph(igraph_t* graph, vector<size_t> const& node_sizes)
+Graph* Graph::GraphFromNodeSizes(igraph_t* graph, vector<double> const& node_sizes)
 {
-  this->_graph = graph;
-  this->_remove_graph = false;
-  this->set_defaults();
-  this->_is_weighted = false;
+  Graph* g = new Graph(graph);
 
-  if (node_sizes.size() != this->vcount())
+  g->_graph = graph;
+  g->_remove_graph = false;
+  g->set_defaults();
+  g->_is_weighted = false;
+
+  if (node_sizes.size() != g->vcount())
     throw Exception("Node size vector inconsistent length with the vertex count of the graph.");
 
-  this->_node_sizes = node_sizes;
+  g->_node_sizes = node_sizes;
 
-  this->_correct_self_loops = this->has_self_loops();
+  g->_correct_self_loops = g->has_self_loops();
 
-  igraph_vector_int_init(&this->_temp_igraph_vector, this->vcount());
-  this->init_admin();
-  this->set_self_weights();
+  igraph_vector_int_init(&g->_temp_igraph_vector, g->vcount());
+  g->init_admin();
+  g->set_self_weights();
+
+  return g;
 }
 
 Graph::Graph(igraph_t* graph, int correct_self_loops)
@@ -284,12 +288,12 @@ int Graph::has_self_loops()
   return has_self_loops;
 }
 
-size_t Graph::possible_edges()
+double Graph::possible_edges()
 {
   return this->possible_edges(this->vcount());
 }
 
-size_t Graph::possible_edges(size_t n)
+double Graph::possible_edges(double n)
 {
   size_t possible_edges = n*(n-1);
   if (!this->is_directed())
@@ -413,7 +417,7 @@ void Graph::init_admin()
 
   // Calculate density;
   double w = this->total_weight();
-  size_t n_size = this->total_size();
+  double n_size = this->total_size();
 
   // For now we default to not correcting self loops.
   // this->_correct_self_loops = false; (remove this as this is set in the constructor)
@@ -747,7 +751,7 @@ Graph* Graph::collapse_graph(MutableVertexPartition* partition)
     throw Exception("Something went wrong with collapsing the graph.");
 
   // Calculate new node sizes
-  vector<size_t> csizes(n_collapsed, 0);
+  vector<double> csizes(n_collapsed, 0);
   for (size_t c = 0; c < partition->n_communities(); c++)
     csizes[c] = partition->csize(c);
 

--- a/src/leidenalg/ModularityVertexPartition.cpp
+++ b/src/leidenalg/ModularityVertexPartition.cpp
@@ -148,7 +148,7 @@ double ModularityVertexPartition::quality()
     double w_out = this->total_weight_from_comm(c);
     double w_in = this->total_weight_to_comm(c);
     #ifdef DEBUG
-      size_t csize = this->csize(c);
+      double csize = this->csize(c);
       cerr << "\t" << "Comm: " << c << ", size=" << csize << ", w=" << w << ", w_out=" << w_out << ", w_in=" << w_in << "." << endl;
     #endif
     mod += w - w_out*w_in/((this->graph->is_directed() ? 1.0 : 4.0)*this->graph->total_weight());

--- a/src/leidenalg/MutableVertexPartition.cpp
+++ b/src/leidenalg/MutableVertexPartition.cpp
@@ -72,7 +72,7 @@ void MutableVertexPartition::clean_mem()
 
 }
 
-size_t MutableVertexPartition::csize(size_t comm)
+double MutableVertexPartition::csize(size_t comm)
 {
   if (comm < this->_csize.size())
     return this->_csize[comm];
@@ -213,8 +213,8 @@ void MutableVertexPartition::init_admin()
   this->_total_possible_edges_in_all_comms = 0;
   for (size_t c = 0; c < this->_n_communities; c++)
   {
-    size_t n_c = this->csize(c);
-    size_t possible_edges = this->graph->possible_edges(n_c);
+    double n_c = this->csize(c);
+    double possible_edges = this->graph->possible_edges(n_c);
 
     #ifdef DEBUG
       cerr << "\t" << "c=" << c << ", n_c=" << n_c << ", possible_edges=" << possible_edges << endl;
@@ -283,7 +283,7 @@ void MutableVertexPartition::relabel_communities(vector<size_t> const& new_comm_
   vector<double> new_total_weight_in_comm(nbcomms, 0.0);
   vector<double> new_total_weight_from_comm(nbcomms, 0.0);
   vector<double> new_total_weight_to_comm(nbcomms, 0.0);
-  vector<size_t> new_csize(nbcomms, 0);
+  vector<double> new_csize(nbcomms, 0);
   vector<size_t> new_cnodes(nbcomms, 0);
 
   // Relabel community admin
@@ -391,7 +391,7 @@ vector<size_t> MutableVertexPartition::rank_order_communities(vector<MutableVert
   vector<size_t*> csizes;
   for (size_t i = 0; i < nb_comms; i++)
   {
-      size_t csize = 0;
+      double csize = 0;
       for (size_t layer = 0; layer < nb_layers; layer++)
         csize += partitions[layer]->csize(i);
 
@@ -559,7 +559,7 @@ void MutableVertexPartition::move_node(size_t v,size_t new_comm)
   }
 
   // Keep track of all possible edges in all communities;
-  size_t node_size = this->graph->node_size(v);
+  double node_size = this->graph->node_size(v);
   size_t old_comm = this->_membership[v];
   #ifdef DEBUG
     cerr << "Node size: " << node_size << ", old comm: " << old_comm << ", new comm: " << new_comm << endl;

--- a/src/leidenalg/Optimiser.cpp
+++ b/src/leidenalg/Optimiser.cpp
@@ -646,7 +646,7 @@ double Optimiser::move_nodes(vector<MutableVertexPartition*> partitions, vector<
 
     size_t max_comm = v_comm;
     double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 10*DBL_EPSILON;
-    size_t v_size = graphs[0]->node_size(v);
+    double v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
       // reset comm_added to all false
@@ -895,7 +895,7 @@ double Optimiser::merge_nodes(vector<MutableVertexPartition*> partitions, vector
 
       size_t max_comm = v_comm;
       double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 0;
-      size_t v_size = graphs[0]->node_size(v);
+      double v_size = graphs[0]->node_size(v);
       for (size_t comm : comms)
       {
         // Do not create too-large communities.
@@ -1119,7 +1119,7 @@ double Optimiser::move_nodes_constrained(vector<MutableVertexPartition*> partiti
 
     size_t max_comm = v_comm;
     double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 10*DBL_EPSILON;
-    size_t v_size = graphs[0]->node_size(v);
+    double v_size = graphs[0]->node_size(v);
     for (size_t comm : comms)
     {
       // Do not create too-large communities.
@@ -1358,7 +1358,7 @@ double Optimiser::merge_nodes_constrained(vector<MutableVertexPartition*> partit
 
       size_t max_comm = v_comm;
       double max_improv = (0 < max_comm_size && max_comm_size < partitions[0]->csize(v_comm)) ? -INFINITY : 0;
-      size_t v_size = graphs[0]->node_size(v);
+      double v_size = graphs[0]->node_size(v);
       for (size_t comm : comms)
       {
         // reset comm_added to all false

--- a/src/leidenalg/RBConfigurationVertexPartition.cpp
+++ b/src/leidenalg/RBConfigurationVertexPartition.cpp
@@ -147,7 +147,7 @@ double RBConfigurationVertexPartition::quality(double resolution_parameter)
     double w_out = this->total_weight_from_comm(c);
     double w_in = this->total_weight_to_comm(c);
     #ifdef DEBUG
-      size_t csize = this->csize(c);
+      double csize = this->csize(c);
       cerr << "\t" << "Comm: " << c << ", size=" << csize << ", w=" << w << ", w_out=" << w_out << ", w_in=" << w_in << "." << endl;
     #endif
     mod += w - resolution_parameter*w_out*w_in/((this->graph->is_directed() ? 1.0 : 4.0)*this->graph->total_weight());

--- a/src/leidenalg/RBERVertexPartition.cpp
+++ b/src/leidenalg/RBERVertexPartition.cpp
@@ -63,15 +63,15 @@ double RBERVertexPartition::diff_move(size_t v, size_t new_comm)
     #ifdef DEBUG
       cerr << "\t" << "w_from_new: " << w_from_new << endl;
     #endif
-    size_t nsize = this->graph->node_size(v);
+    double nsize = this->graph->node_size(v);
     #ifdef DEBUG
       cerr << "\t" << "nsize: " << nsize << endl;
     #endif
-    size_t csize_old = this->csize(old_comm);
+    double csize_old = this->csize(old_comm);
     #ifdef DEBUG
       cerr << "\t" << "csize_old: " << csize_old << endl;
     #endif
-    size_t csize_new = this->csize(new_comm);
+    double csize_new = this->csize(new_comm);
     #ifdef DEBUG
       cerr << "\t" << "csize_new: " << csize_new << endl;
     #endif
@@ -126,9 +126,9 @@ double RBERVertexPartition::quality(double resolution_parameter)
   double mod = 0.0;
   for (size_t c = 0; c < this->n_communities(); c++)
   {
-    size_t csize = this->csize(c);
+    double csize = this->csize(c);
     double w = this->total_weight_in_comm(c);
-    size_t comm_possible_edges = this->graph->possible_edges(csize);
+    double comm_possible_edges = this->graph->possible_edges(csize);
 
     #ifdef DEBUG
       cerr << "\t" << "Comm: " << c << ", w_c=" << w << ", n_c=" << csize << ", comm_possible_edges=" << comm_possible_edges << ", p=" << this->graph->density() << "." << endl;

--- a/src/leidenalg/SignificanceVertexPartition.cpp
+++ b/src/leidenalg/SignificanceVertexPartition.cpp
@@ -35,21 +35,21 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
     cerr << "virtual double SignificanceVertexPartition::diff_move(" << v << ", " << new_comm << ")" << endl;
   #endif
   size_t old_comm = this->membership(v);
-  size_t nsize = this->graph->node_size(v);
+  double nsize = this->graph->node_size(v);
   double diff = 0.0;
   if (new_comm != old_comm)
   {
     double normalise = (2.0 - this->graph->is_directed());
     double p = this->graph->density();
     #ifdef DEBUG
-      size_t n = this->graph->total_size();
+      double n = this->graph->total_size();
       cerr << "\t" << "Community: " << old_comm << " => " << new_comm << "." << endl;
       cerr << "\t" << "n: " << n << ", m: " << this->graph->total_weight() << ", p: " << p << "." << endl;
     #endif
 
     //Old comm
-    size_t n_old = this->csize(old_comm);
-    size_t N_old = this->graph->possible_edges(n_old);
+    double n_old = this->csize(old_comm);
+    double N_old = this->graph->possible_edges(n_old);
     double m_old = this->total_weight_in_comm(old_comm);
     double q_old = 0.0;
     if (N_old > 0)
@@ -59,8 +59,8 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
            << ", KL: " << KL(q_old, p)  << "." << endl;
     #endif
     // Old comm after move
-    size_t n_oldx = n_old - nsize; // It should not be possible that this becomes negative, so no need for ptrdiff_t here.
-    size_t N_oldx = this->graph->possible_edges(n_oldx);
+    double n_oldx = n_old - nsize; // It should not be possible that this becomes negative, so no need for ptrdiff_t here.
+    double N_oldx = this->graph->possible_edges(n_oldx);
     double sw = this->graph->node_self_weight(v);
     // Be careful to exclude the self weight here, because this is include in the weight_to_comm function.
     double wtc = this->weight_to_comm(v, old_comm) - sw;
@@ -78,8 +78,8 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
     #endif
 
     // New comm
-    size_t n_new = this->csize(new_comm);
-    size_t N_new = this->graph->possible_edges(n_new);
+    double n_new = this->csize(new_comm);
+    double N_new = this->graph->possible_edges(n_new);
     double m_new = this->total_weight_in_comm(new_comm);
     double q_new = 0.0;
     if (N_new > 0)
@@ -90,8 +90,8 @@ double SignificanceVertexPartition::diff_move(size_t v, size_t new_comm)
     #endif
 
     // New comm after move
-    size_t n_newx = n_new + nsize;
-    size_t N_newx = this->graph->possible_edges(n_newx);
+    double n_newx = n_new + nsize;
+    double N_newx = this->graph->possible_edges(n_newx);
     wtc = this->weight_to_comm(v, new_comm);
     wfc = this->weight_from_comm(v, new_comm);
     sw = this->graph->node_self_weight(v);
@@ -134,7 +134,7 @@ double SignificanceVertexPartition::quality()
 {
   #ifdef DEBUG
     cerr << "double SignificanceVertexPartition::quality()";
-    size_t n = this->graph->total_size();
+    double n = this->graph->total_size();
   #endif
   double S = 0.0;
   double p = this->graph->density();
@@ -143,7 +143,7 @@ double SignificanceVertexPartition::quality()
   #endif
   for (size_t c = 0; c < this->n_communities(); c++)
   {
-    size_t n_c = this->csize(c);
+    double n_c = this->csize(c);
     double m_c = this->total_weight_in_comm(c);
     double p_c = 0.0;
     size_t N_c = this->graph->possible_edges(n_c);

--- a/src/leidenalg/VertexPartition.py
+++ b/src/leidenalg/VertexPartition.py
@@ -890,7 +890,7 @@ class CPMVertexPartition(LinearResolutionParameterVertexPartition):
          resolution-limit-free community detection.  Physical Review E, 84(1),
          016114.  `10.1103/PhysRevE.84.016114 <http://doi.org/10.1103/PhysRevE.84.016114>`_
    """
-  def __init__(self, graph, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1.0):
+  def __init__(self, graph, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1.0, correct_self_loops=None):
     """
     Parameters
     ----------
@@ -935,8 +935,11 @@ class CPMVertexPartition(LinearResolutionParameterVertexPartition):
         # Make sure it is a list
         node_sizes = list(node_sizes)
 
+    if correct_self_loops is None:
+      correct_self_loops = any(graph.is_loop())
+
     self._partition = _c_leiden._new_CPMVertexPartition(pygraph_t,
-        initial_membership, weights, node_sizes, resolution_parameter)
+        initial_membership, weights, node_sizes, resolution_parameter, correct_self_loops)
     self._update_internal_membership()
 
   def __deepcopy__(self, memo):

--- a/src/leidenalg/python_partition_interface.cpp
+++ b/src/leidenalg/python_partition_interface.cpp
@@ -30,7 +30,7 @@ Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyO
   size_t n = igraph_vcount(py_graph);
   size_t m = igraph_ecount(py_graph);
 
-  vector<size_t> node_sizes;
+  vector<double> node_sizes;
   vector<double> weights;
   if (py_node_sizes != NULL && py_node_sizes != Py_None)
   {
@@ -47,14 +47,14 @@ Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyO
     for (size_t v = 0; v < n; v++)
     {
       PyObject* py_item = PyList_GetItem(py_node_sizes, v);
-      if (PyNumber_Check(py_item) && PyIndex_Check(py_item))
+      if (PyNumber_Check(py_item))
       {
-        size_t e = PyLong_AsSize_t(PyNumber_Long(py_item));
+        double e = PyFloat_AsDouble(py_item);
         node_sizes[v] = e;
       }
       else
       {
-        throw Exception("Expected integer value for node sizes vector.");
+        throw Exception("Expected numerical values for node sizes vector.");
       }
     }
   }
@@ -104,12 +104,12 @@ Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyO
     if (weights.size() == m)
       graph = new Graph(py_graph, weights, node_sizes, correct_self_loops);
     else
-      graph = new Graph(py_graph, node_sizes, correct_self_loops);
+      graph = Graph::GraphFromNodeSizes(py_graph, node_sizes, correct_self_loops);
   }
   else
   {
     if (weights.size() == m)
-      graph = new Graph(py_graph, weights, correct_self_loops);
+      graph = Graph::GraphFromEdgeWeights(py_graph, weights, correct_self_loops);
     else
       graph = new Graph(py_graph, correct_self_loops);
   }

--- a/src/leidenalg/python_partition_interface.cpp
+++ b/src/leidenalg/python_partition_interface.cpp
@@ -2,15 +2,15 @@
 
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes)
 {
-  return create_graph_from_py(py_obj_graph, py_node_sizes, NULL, true);
+  return create_graph_from_py(py_obj_graph, py_node_sizes, NULL, true, false);
 }
 
 Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights)
 {
-  return create_graph_from_py(py_obj_graph, py_node_sizes, py_weights, true);
+  return create_graph_from_py(py_obj_graph, py_node_sizes, py_weights, true, false);
 }
 
-Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, int check_positive_weight)
+Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyObject* py_weights, bool check_positive_weight, bool correct_self_loops)
 {
   #ifdef DEBUG
     cerr << "create_graph_from_py" << endl;
@@ -97,8 +97,6 @@ Graph* create_graph_from_py(PyObject* py_obj_graph, PyObject* py_node_sizes, PyO
     }
   }
 
-  // TODO: Pass correct_for_self_loops as parameter
-  int correct_self_loops = false;
   if (node_sizes.size() == n)
   {
     if (weights.size() == m)
@@ -317,17 +315,18 @@ extern "C"
     PyObject* py_weights = NULL;
     PyObject* py_node_sizes = NULL;
     double resolution_parameter = 1.0;
+    int correct_self_loops = false;
 
-    static const char* kwlist[] = {"graph", "initial_membership", "weights", "node_sizes", "resolution_parameter", NULL};
+    static const char* kwlist[] = {"graph", "initial_membership", "weights", "node_sizes", "resolution_parameter", "correct_self_loops", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OOOd", (char**) kwlist,
-                                     &py_obj_graph, &py_initial_membership, &py_weights, &py_node_sizes, &resolution_parameter))
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O|OOOdp", (char**) kwlist,
+                                     &py_obj_graph, &py_initial_membership, &py_weights, &py_node_sizes, &resolution_parameter, &correct_self_loops))
         return NULL;
 
     try
     {
 
-      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights, false);
+      Graph* graph = create_graph_from_py(py_obj_graph, py_node_sizes, py_weights, false, correct_self_loops);
 
       CPMVertexPartition* partition = NULL;
 


### PR DESCRIPTION
This fixes the request by @arnaudon in https://github.com/vtraag/leidenalg/pull/109#issuecomment-1284984882 by changing `node_size` to a `double` instead of `size_t`.

This also required some changes in some contructors, because they could no longer be discerned on the basis of their call signature.