### PR TITLE
Allow python-igraph 0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Sociology"
 ]
 dependencies = [
-    "igraph >= 0.10.0,< 0.11",
+    "igraph >= 0.10.0,< 0.12",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
as it is still built on C/igraph 0.10, therefore compatible