### PR TITLE
Upgrade: Allow also python-igraph 0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Sociology"
 ]
 dependencies = [
-    "igraph >= 0.10.0,< 0.11",
+    "igraph >= 0.10.0,< 0.12",
 ]
 dynamic = ["version"]
 

--- a/scripts/build_igraph.bat
+++ b/scripts/build_igraph.bat
@@ -1,6 +1,6 @@
 @echo off
 
-set IGRAPH_VERSION=0.10.4
+set IGRAPH_VERSION=0.10.8
 
 set ROOT_DIR=%cd%
 echo Using root dir %ROOT_DIR%


### PR DESCRIPTION
This fixes #163. If I'm not mistaken, `leidenalg` can support working with python-igraph 0.10 and 0.11. I've also updated the C core to 0.10.8 (used in CI to build binary wheels), which shouldn't affect working with either python-igraph 0.10 or 0.11.

All tests pass locally for both python-igraph 0.10 and 0.11. Once CI passes, I'll merge, bump and release.