### PR TITLE
SyntaxWarnings: Invalid escape sequences.

### DIFF
--- a/src/leidenalg/Optimiser.py
+++ b/src/leidenalg/Optimiser.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from math import log, sqrt
 
 class Optimiser(object):
-  """ Class for doing community detection using the Leiden algorithm.
+  r""" Class for doing community detection using the Leiden algorithm.
 
   The Leiden algorithm [1] derives from the Louvain algorithm [2]. The Louvain
   algorithm has an elegant formulation. It consists of two phases: (1) move
@@ -308,7 +308,7 @@ class Optimiser(object):
     return diff
 
   def optimise_partition_multiplex(self, partitions, layer_weights=None, n_iterations=2, is_membership_fixed=None):
-    """ Optimise the given partitions simultaneously.
+    r""" Optimise the given partitions simultaneously.
 
     Parameters
     ----------

--- a/src/leidenalg/VertexPartition.py
+++ b/src/leidenalg/VertexPartition.py
@@ -385,7 +385,7 @@ class MutableVertexPartition(_ig.VertexClustering):
     return _c_leiden._MutableVertexPartition_weight_from_comm(self._partition, v, comm)
 
 class ModularityVertexPartition(MutableVertexPartition):
-  """ Implements modularity. This quality function is well-defined only for positive edge weights.
+  r""" Implements modularity. This quality function is well-defined only for positive edge weights.
 
   Notes
   -----
@@ -758,7 +758,7 @@ class RBERVertexPartition(LinearResolutionParameterVertexPartition):
     return new_partition
 
 class RBConfigurationVertexPartition(LinearResolutionParameterVertexPartition):
-  """ Implements Reichardt and Bornholdt's Potts model with a configuration null model.
+  r""" Implements Reichardt and Bornholdt's Potts model with a configuration null model.
   This quality function is well-defined only for positive edge weights.
   This quality function uses a linear resolution parameter.
 


### PR DESCRIPTION
As seen at least with Python 3.13, a number of Python entities descriptions are raising warnings, caught in pytest's summary:

	leidenalg/VertexPartition.py:388
	  /build/reproducible-path/python-leidenalg-0.10.2/.pybuild/cpython3_3.13_leidenalg/build/leidenalg/VertexPartition.py:388: SyntaxWarning: invalid escape sequence '\m'
	    """ Implements modularity. This quality function is well-defined only for positive edge weights.

	leidenalg/VertexPartition.py:761
	  /build/reproducible-path/python-leidenalg-0.10.2/.pybuild/cpython3_3.13_leidenalg/build/leidenalg/VertexPartition.py:761: SyntaxWarning: invalid escape sequence '\m'
	    """ Implements Reichardt and Bornholdt's Potts model with a configuration null model.

	leidenalg/Optimiser.py:7
	  /build/reproducible-path/python-leidenalg-0.10.2/.pybuild/cpython3_3.13_leidenalg/build/leidenalg/Optimiser.py:7: SyntaxWarning: invalid escape sequence '\g'
	    """ Class for doing community detection using the Leiden algorithm.

	leidenalg/Optimiser.py:305
	  /build/reproducible-path/python-leidenalg-0.10.2/.pybuild/cpython3_3.13_leidenalg/build/leidenalg/Optimiser.py:305: SyntaxWarning: invalid escape sequence '\s'
	    """ Optimise the given partitions simultaneously.

This change declares the classes and function descriptions as raw strings, to avoid tripping the invalid escape sequence.

This has been initially reported as [Debian bug #1085929].

[Debian bug #1085929]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085929