### PR TITLE
Ensure is_membership_fixed is passed as a list

### DIFF
--- a/src/leidenalg/Optimiser.py
+++ b/src/leidenalg/Optimiser.py
@@ -291,6 +291,11 @@ class Optimiser(object):
     itr = 0
     diff = 0
     continue_iteration = itr < n_iterations or n_iterations < 0
+
+    if is_membership_fixed is not None:
+      # Make sure it is a list
+      is_membership_fixed = list(is_membership_fixed)
+
     while continue_iteration:
       diff_inc = _c_leiden._Optimiser_optimise_partition(
               self._optimiser,

--- a/src/leidenalg/python_optimiser_interface.cpp
+++ b/src/leidenalg/python_optimiser_interface.cpp
@@ -83,7 +83,7 @@ extern "C"
       size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
       if (nb_is_membership_fixed != n)
       {
-        PyErr_SetString(PyExc_ValueError, "Node size vector not the same size as the number of nodes.");
+        PyErr_SetString(PyExc_ValueError, "Membership fixed vector not the same size as the number of nodes.");
         return NULL;
       }
 
@@ -188,7 +188,7 @@ extern "C"
       size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
       if (nb_is_membership_fixed != n)
       {
-        PyErr_SetString(PyExc_TypeError, "Node size vector not the same size as the number of nodes.");
+        PyErr_SetString(PyExc_TypeError, "Membership fixed vector not the same size as the number of nodes.");
         return NULL;
       }
 
@@ -270,7 +270,7 @@ extern "C"
       size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
       if (nb_is_membership_fixed != n)
       {
-        PyErr_SetString(PyExc_TypeError, "Node size vector not the same size as the number of nodes.");
+        PyErr_SetString(PyExc_TypeError, "Membership fixed vector not the same size as the number of nodes.");
         return NULL;
       }
 
@@ -346,7 +346,7 @@ extern "C"
       size_t nb_is_membership_fixed = PyList_Size(py_is_membership_fixed);
       if (nb_is_membership_fixed != n)
       {
-        PyErr_SetString(PyExc_TypeError, "Node size vector not the same size as the number of nodes.");
+        PyErr_SetString(PyExc_TypeError, "Membership fixed vector not the same size as the number of nodes.");
         return NULL;
       }
 


### PR DESCRIPTION
This fixes a problem with numpy arrays being passed that were not interpreted as a list.