### PR TITLE
fix: allow 64-bit rng seed

### DIFF
--- a/src/leidenalg/python_optimiser_interface.cpp
+++ b/src/leidenalg/python_optimiser_interface.cpp
@@ -925,14 +925,14 @@ extern "C"
   PyObject* _Optimiser_set_rng_seed(PyObject *self, PyObject *args, PyObject *keywds)
   {
     PyObject* py_optimiser = NULL;
-    int seed = 0;
+    size_t seed = 0;
     static const char* kwlist[] = {"optimiser", "seed", NULL};
 
     #ifdef DEBUG
       cerr << "Parsing arguments..." << endl;
     #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Oi", (char**) kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "On", (char**) kwlist,
                                     &py_optimiser, &seed))
        return NULL;
 


### PR DESCRIPTION
This should fix #223. It is a simple case of using `size_t` and accepting a `Py_ssize_t` argument (note that there are some difference between the two: https://peps.python.org/pep-0353/).